### PR TITLE
[VYMCA-3] Add openy_gc_storage module with node types and taxonomy for GC

### DIFF
--- a/modules/openy_gc_demo/openy_gc_demo.info.yml
+++ b/modules/openy_gc_demo/openy_gc_demo.info.yml
@@ -7,3 +7,4 @@ core: 8.x
 dependencies:
   - drupal:default_content
   - drupal:openy_gated_content
+  - drupal:openy_gc_storage

--- a/modules/openy_gc_storage/config/install/core.entity_form_display.node.gc_video.default.yml
+++ b/modules/openy_gc_storage/config/install/core.entity_form_display.node.gc_video.default.yml
@@ -1,0 +1,170 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - entity_browser.browser.videos_library
+    - field.field.node.gc_video.field_gc_video_category
+    - field.field.node.gc_video.field_gc_video_description
+    - field.field.node.gc_video.field_gc_video_duration
+    - field.field.node.gc_video.field_gc_video_equipment
+    - field.field.node.gc_video.field_gc_video_instructor
+    - field.field.node.gc_video.field_gc_video_level
+    - field.field.node.gc_video.field_gc_video_media
+    - node.type.gc_video
+  module:
+    - openy_focal_point
+    - path
+    - scheduler
+    - text
+id: node.gc_video.default
+targetEntityType: node
+bundle: gc_video
+mode: default
+content:
+  created:
+    type: datetime_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_gc_video_category:
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+    region: content
+  field_gc_video_description:
+    weight: 1
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
+    type: text_textarea
+    region: content
+  field_gc_video_duration:
+    weight: 7
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: number
+    region: content
+  field_gc_video_equipment:
+    weight: 6
+    settings:
+      match_operator: CONTAINS
+      match_limit: 10
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete_tags
+    region: content
+  field_gc_video_instructor:
+    weight: 4
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+    region: content
+  field_gc_video_level:
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+    type: options_select
+    region: content
+  field_gc_video_media:
+    type: openy_focal_point_entity_browser_entity_reference
+    weight: 2
+    settings:
+      entity_browser: videos_library
+      field_widget_display: label
+      field_widget_edit: '1'
+      field_widget_remove: '1'
+      selection_mode: selection_append
+      field_widget_replace: 0
+      open: 0
+      field_widget_display_settings: {  }
+    third_party_settings: {  }
+    region: content
+  langcode:
+    type: language_select
+    weight: 8
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 15
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 11
+    region: content
+    third_party_settings: {  }
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 14
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  redirect:
+    type: string_textfield
+    weight: 16
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 18
+    region: content
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 12
+    region: content
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 9
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+      match_limit: 10
+    region: content
+    third_party_settings: {  }
+  unpublish_on:
+    type: datetime_timestamp_no_default
+    weight: 13
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  url_redirects:
+    weight: 17
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/openy_gc_storage/config/install/core.entity_view_display.node.gc_video.default.yml
+++ b/modules/openy_gc_storage/config/install/core.entity_view_display.node.gc_video.default.yml
@@ -1,0 +1,84 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.gc_video.field_gc_video_category
+    - field.field.node.gc_video.field_gc_video_description
+    - field.field.node.gc_video.field_gc_video_duration
+    - field.field.node.gc_video.field_gc_video_equipment
+    - field.field.node.gc_video.field_gc_video_instructor
+    - field.field.node.gc_video.field_gc_video_level
+    - field.field.node.gc_video.field_gc_video_media
+    - node.type.gc_video
+  module:
+    - text
+    - user
+id: node.gc_video.default
+targetEntityType: node
+bundle: gc_video
+mode: default
+content:
+  field_gc_video_category:
+    weight: 102
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_gc_video_description:
+    weight: 101
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    type: text_default
+    region: content
+  field_gc_video_duration:
+    weight: 107
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    type: number_integer
+    region: content
+  field_gc_video_equipment:
+    weight: 105
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_gc_video_instructor:
+    weight: 104
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+    region: content
+  field_gc_video_level:
+    weight: 106
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+  field_gc_video_media:
+    type: entity_reference_entity_view
+    weight: 103
+    label: above
+    settings:
+      view_mode: default
+      link: false
+    third_party_settings: {  }
+    region: content
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  langcode: true

--- a/modules/openy_gc_storage/config/install/core.entity_view_display.node.gc_video.teaser.yml
+++ b/modules/openy_gc_storage/config/install/core.entity_view_display.node.gc_video.teaser.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.gc_video.field_gc_video_category
+    - field.field.node.gc_video.field_gc_video_description
+    - field.field.node.gc_video.field_gc_video_duration
+    - field.field.node.gc_video.field_gc_video_equipment
+    - field.field.node.gc_video.field_gc_video_instructor
+    - field.field.node.gc_video.field_gc_video_level
+    - field.field.node.gc_video.field_gc_video_media
+    - node.type.gc_video
+  module:
+    - user
+id: node.gc_video.teaser
+targetEntityType: node
+bundle: gc_video
+mode: teaser
+content:
+  links:
+    weight: 100
+    settings: {  }
+    third_party_settings: {  }
+    region: content
+hidden:
+  field_gc_video_category: true
+  field_gc_video_description: true
+  field_gc_video_duration: true
+  field_gc_video_equipment: true
+  field_gc_video_instructor: true
+  field_gc_video_level: true
+  field_gc_video_media: true
+  langcode: true

--- a/modules/openy_gc_storage/config/install/core.entity_view_display.taxonomy_term.gc_category.default.yml
+++ b/modules/openy_gc_storage/config/install/core.entity_view_display.taxonomy_term.gc_category.default.yml
@@ -1,0 +1,30 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.gc_category.field_gc_category_media
+    - taxonomy.vocabulary.gc_category
+  module:
+    - text
+id: taxonomy_term.gc_category.default
+targetEntityType: taxonomy_term
+bundle: gc_category
+mode: default
+content:
+  description:
+    label: hidden
+    type: text_default
+    weight: 0
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_gc_category_media:
+    weight: 1
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+    region: content
+hidden:
+  langcode: true

--- a/modules/openy_gc_storage/config/install/field.field.node.gc_video.field_gc_video_category.yml
+++ b/modules/openy_gc_storage/config/install/field.field.node.gc_video.field_gc_video_category.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_gc_video_category
+    - node.type.gc_video
+    - taxonomy.vocabulary.gc_category
+  module:
+    - datalayer
+third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_gc_video_category
+id: node.gc_video.field_gc_video_category
+field_name: field_gc_video_category
+entity_type: node
+bundle: gc_video
+label: Category
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      gc_category: gc_category
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/openy_gc_storage/config/install/field.field.node.gc_video.field_gc_video_description.yml
+++ b/modules/openy_gc_storage/config/install/field.field.node.gc_video.field_gc_video_description.yml
@@ -1,0 +1,25 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_gc_video_description
+    - node.type.gc_video
+  module:
+    - datalayer
+    - text
+third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_gc_video_description
+id: node.gc_video.field_gc_video_description
+field_name: field_gc_video_description
+entity_type: node
+bundle: gc_video
+label: Description
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: text_long

--- a/modules/openy_gc_storage/config/install/field.field.node.gc_video.field_gc_video_duration.yml
+++ b/modules/openy_gc_storage/config/install/field.field.node.gc_video.field_gc_video_duration.yml
@@ -1,0 +1,28 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_gc_video_duration
+    - node.type.gc_video
+  module:
+    - datalayer
+third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_gc_video_duration
+id: node.gc_video.field_gc_video_duration
+field_name: field_gc_video_duration
+entity_type: node
+bundle: gc_video
+label: Duration
+description: 'Video duration in seconds'
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/modules/openy_gc_storage/config/install/field.field.node.gc_video.field_gc_video_equipment.yml
+++ b/modules/openy_gc_storage/config/install/field.field.node.gc_video.field_gc_video_equipment.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_gc_video_equipment
+    - node.type.gc_video
+    - taxonomy.vocabulary.gc_equipment
+  module:
+    - datalayer
+third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_gc_video_equipment
+id: node.gc_video.field_gc_video_equipment
+field_name: field_gc_video_equipment
+entity_type: node
+bundle: gc_video
+label: Equipment
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      gc_equipment: gc_equipment
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: gc_equipment
+field_type: entity_reference

--- a/modules/openy_gc_storage/config/install/field.field.node.gc_video.field_gc_video_instructor.yml
+++ b/modules/openy_gc_storage/config/install/field.field.node.gc_video.field_gc_video_instructor.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_gc_video_instructor
+    - node.type.gc_video
+  module:
+    - datalayer
+third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_gc_video_instructor
+id: node.gc_video.field_gc_video_instructor
+field_name: field_gc_video_instructor
+entity_type: node
+bundle: gc_video
+label: 'Instructor name'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/modules/openy_gc_storage/config/install/field.field.node.gc_video.field_gc_video_level.yml
+++ b/modules/openy_gc_storage/config/install/field.field.node.gc_video.field_gc_video_level.yml
@@ -1,0 +1,34 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_gc_video_level
+    - node.type.gc_video
+    - taxonomy.vocabulary.gc_level
+  module:
+    - datalayer
+third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_gc_video_level
+id: node.gc_video.field_gc_video_level
+field_name: field_gc_video_level
+entity_type: node
+bundle: gc_video
+label: Level
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      gc_level: gc_level
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/openy_gc_storage/config/install/field.field.node.gc_video.field_gc_video_media.yml
+++ b/modules/openy_gc_storage/config/install/field.field.node.gc_video.field_gc_video_media.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_gc_video_media
+    - media.type.video
+    - node.type.gc_video
+  module:
+    - datalayer
+third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_gc_video_media
+id: node.gc_video.field_gc_video_media
+field_name: field_gc_video_media
+entity_type: node
+bundle: gc_video
+label: Media
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      video: video
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/openy_gc_storage/config/install/field.field.taxonomy_term.gc_category.field_gc_category_media.yml
+++ b/modules/openy_gc_storage/config/install/field.field.taxonomy_term.gc_category.field_gc_category_media.yml
@@ -1,0 +1,33 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_gc_category_media
+    - media.type.image
+    - taxonomy.vocabulary.gc_category
+  module:
+    - datalayer
+third_party_settings:
+  datalayer:
+    expose: 0
+    label: field_gc_category_media
+id: taxonomy_term.gc_category.field_gc_category_media
+field_name: field_gc_category_media
+entity_type: taxonomy_term
+bundle: gc_category
+label: Media
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:media'
+  handler_settings:
+    target_bundles:
+      image: image
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/modules/openy_gc_storage/config/install/field.storage.node.field_gc_video_category.yml
+++ b/modules/openy_gc_storage/config/install/field.storage.node.field_gc_video_category.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_gc_video_category
+field_name: field_gc_video_category
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/openy_gc_storage/config/install/field.storage.node.field_gc_video_description.yml
+++ b/modules/openy_gc_storage/config/install/field.storage.node.field_gc_video_description.yml
@@ -1,0 +1,18 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - text
+id: node.field_gc_video_description
+field_name: field_gc_video_description
+entity_type: node
+type: text_long
+settings: {  }
+module: text
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/openy_gc_storage/config/install/field.storage.node.field_gc_video_duration.yml
+++ b/modules/openy_gc_storage/config/install/field.storage.node.field_gc_video_duration.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_gc_video_duration
+field_name: field_gc_video_duration
+entity_type: node
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/openy_gc_storage/config/install/field.storage.node.field_gc_video_equipment.yml
+++ b/modules/openy_gc_storage/config/install/field.storage.node.field_gc_video_equipment.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_gc_video_equipment
+field_name: field_gc_video_equipment
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/openy_gc_storage/config/install/field.storage.node.field_gc_video_instructor.yml
+++ b/modules/openy_gc_storage/config/install/field.storage.node.field_gc_video_instructor.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_gc_video_instructor
+field_name: field_gc_video_instructor
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/openy_gc_storage/config/install/field.storage.node.field_gc_video_level.yml
+++ b/modules/openy_gc_storage/config/install/field.storage.node.field_gc_video_level.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_gc_video_level
+field_name: field_gc_video_level
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/openy_gc_storage/config/install/field.storage.node.field_gc_video_media.yml
+++ b/modules/openy_gc_storage/config/install/field.storage.node.field_gc_video_media.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - node
+id: node.field_gc_video_media
+field_name: field_gc_video_media
+entity_type: node
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/openy_gc_storage/config/install/field.storage.taxonomy_term.field_gc_category_media.yml
+++ b/modules/openy_gc_storage/config/install/field.storage.taxonomy_term.field_gc_category_media.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - media
+    - taxonomy
+id: taxonomy_term.field_gc_category_media
+field_name: field_gc_category_media
+entity_type: taxonomy_term
+type: entity_reference
+settings:
+  target_type: media
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/openy_gc_storage/config/install/language.content_settings.node.gc_video.yml
+++ b/modules/openy_gc_storage/config/install/language.content_settings.node.gc_video.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.gc_video
+id: node.gc_video
+target_entity_type_id: node
+target_bundle: gc_video
+default_langcode: site_default
+language_alterable: false

--- a/modules/openy_gc_storage/config/install/language.content_settings.taxonomy_term.gc_category.yml
+++ b/modules/openy_gc_storage/config/install/language.content_settings.taxonomy_term.gc_category.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.gc_category
+id: taxonomy_term.gc_category
+target_entity_type_id: taxonomy_term
+target_bundle: gc_category
+default_langcode: site_default
+language_alterable: false

--- a/modules/openy_gc_storage/config/install/language.content_settings.taxonomy_term.gc_equipment.yml
+++ b/modules/openy_gc_storage/config/install/language.content_settings.taxonomy_term.gc_equipment.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.gc_equipment
+id: taxonomy_term.gc_equipment
+target_entity_type_id: taxonomy_term
+target_bundle: gc_equipment
+default_langcode: site_default
+language_alterable: false

--- a/modules/openy_gc_storage/config/install/language.content_settings.taxonomy_term.gc_instructor.yml
+++ b/modules/openy_gc_storage/config/install/language.content_settings.taxonomy_term.gc_instructor.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.gc_instructor
+id: taxonomy_term.gc_instructor
+target_entity_type_id: taxonomy_term
+target_bundle: gc_instructor
+default_langcode: site_default
+language_alterable: false

--- a/modules/openy_gc_storage/config/install/language.content_settings.taxonomy_term.gc_level.yml
+++ b/modules/openy_gc_storage/config/install/language.content_settings.taxonomy_term.gc_level.yml
@@ -1,0 +1,10 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.gc_level
+id: taxonomy_term.gc_level
+target_entity_type_id: taxonomy_term
+target_bundle: gc_level
+default_langcode: site_default
+language_alterable: false

--- a/modules/openy_gc_storage/config/install/node.type.gc_video.yml
+++ b/modules/openy_gc_storage/config/install/node.type.gc_video.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+    - scheduler
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+  scheduler:
+    expand_fieldset: when_required
+    fields_display_mode: vertical_tab
+    publish_enable: false
+    publish_past_date: error
+    publish_required: false
+    publish_revision: false
+    publish_touch: false
+    unpublish_enable: false
+    unpublish_required: false
+    unpublish_revision: false
+name: Video
+type: gc_video
+description: 'Video content type is used for adding videos for a Gated Content'
+help: ''
+new_revision: true
+preview_mode: 1
+display_submitted: false

--- a/modules/openy_gc_storage/config/install/taxonomy.vocabulary.gc_category.yml
+++ b/modules/openy_gc_storage/config/install/taxonomy.vocabulary.gc_category.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'GC Category'
+vid: gc_category
+description: 'Category for Open Y Gated Content'
+weight: 0

--- a/modules/openy_gc_storage/config/install/taxonomy.vocabulary.gc_equipment.yml
+++ b/modules/openy_gc_storage/config/install/taxonomy.vocabulary.gc_equipment.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'GC Equipment'
+vid: gc_equipment
+description: 'Equipment for Open Y Gated Content'
+weight: 0

--- a/modules/openy_gc_storage/config/install/taxonomy.vocabulary.gc_instructor.yml
+++ b/modules/openy_gc_storage/config/install/taxonomy.vocabulary.gc_instructor.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'GC Instructor'
+vid: gc_instructor
+description: 'Instructor for Open Y Gated Content'
+weight: 0

--- a/modules/openy_gc_storage/config/install/taxonomy.vocabulary.gc_level.yml
+++ b/modules/openy_gc_storage/config/install/taxonomy.vocabulary.gc_level.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {  }
+name: 'GC Level'
+vid: gc_level
+description: 'Exercise level for Open Y Gated Content'
+weight: 0

--- a/modules/openy_gc_storage/openy_gc_storage.features.yml
+++ b/modules/openy_gc_storage/openy_gc_storage.features.yml
@@ -1,0 +1,1 @@
+required: true

--- a/modules/openy_gc_storage/openy_gc_storage.info.yml
+++ b/modules/openy_gc_storage/openy_gc_storage.info.yml
@@ -1,0 +1,22 @@
+name: 'Open Y Gated Content Storage'
+description: 'Provides a node types and taxonomy vocabularies for Open Y Gated Content.'
+type: module
+core: 8.x
+dependencies:
+  - drupal:datalayer
+  - drupal:openy_gated_content
+  - drupal:field
+  - drupal:language
+  - drupal:media
+  - drupal:menu_ui
+  - drupal:node
+  - drupal:openy_focal_point
+  - drupal:openy_media_image
+  - drupal:openy_media_video
+  - drupal:path
+  - drupal:scheduler
+  - drupal:taxonomy
+  - drupal:text
+  - drupal:user
+version: 8.x-1.0
+core_incompatible: false


### PR DESCRIPTION
**Steps for review:**

- [ ] Login s admin
- [ ] Enable Field UI module
- [ ] Go to /admin/structure/taxonomy
- [ ] Check that you can see here GC Category, GC Equipment, GC Instructor, GC Level vocabularies
- [ ] Check those vocabularies created according to [specification](https://docs.google.com/document/d/1nhVJBJb1QwO7mw5R-C_ZWh11b5PtYHdFkTl8-b4DyNM/edit#heading=h.4t0hmegvypuj)
- [ ] Go to /admin/structure/taxonomy
- [ ] Check that you can see here GC Category, GC Equipment, GC Instructor, GC Level vocabularies
- [ ] Create some terms for each vocabulary
- [ ] Go to /admin/structure/types
- [ ] Check that you can see here Video content type
Go to /admin/structure/types/manage/gc_video/fields
- [ ] Check that fields created according to [specification](https://docs.google.com/document/d/1nhVJBJb1QwO7mw5R-C_ZWh11b5PtYHdFkTl8-b4DyNM/edit#heading=h.ave88oriykv)
- [ ] Create a video node with filled fields
- [ ] Profit

**TODO:**
- Maybe we need some demo content for this in openy_gc_demo, let's create it later

cc @AndreyMaximov 

