### PR TITLE
[VYMCA-19] Close access to video, live stream pages

### DIFF
--- a/js/gated-content/src/components/LiveStreamListing.vue
+++ b/js/gated-content/src/components/LiveStreamListing.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="listing">
+  <div v-if="listing.length > 0">
     <h2 class="title">{{ title }}</h2>
     <div v-if="loading">Loading...</div>
     <div v-else-if="error">Error loading</div>

--- a/js/gated-content/src/components/VideoListing.vue
+++ b/js/gated-content/src/components/VideoListing.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="listing">
+  <div v-if="listing.length > 0">
     <h2 class="title">{{ title }}</h2>
     <div v-if="loading">Loading...</div>
     <div v-else-if="error">Error loading</div>

--- a/modules/openy_gc_storage/openy_gc_storage.install
+++ b/modules/openy_gc_storage/openy_gc_storage.install
@@ -6,14 +6,20 @@
  */
 
 use Drupal\user\Entity\Role;
+use Drupal\user\RoleInterface;
 
 /**
  * Implements hook_install().
  */
 function openy_gc_storage_install() {
-  $role_object = Role::load('anonymous');
+  $role_object = Role::load(RoleInterface::ANONYMOUS_ID);
   // Allow anonymous view events entities (for JSON API).
   $role_object->grantPermission('view eventinstance entity');
   $role_object->grantPermission('view eventseries entity');
   $role_object->save();
+
+  $role2_object = Role::load(RoleInterface::AUTHENTICATED_ID);
+  // Allow authenticated users access gated content entities pages.
+  $role2_object->grantPermission('view gated content entities pages');
+  $role2_object->save();
 }

--- a/openy_gated_content.permissions.yml
+++ b/openy_gated_content.permissions.yml
@@ -1,0 +1,3 @@
+view gated content entities pages:
+  title: 'View gated content entities pages'
+  description: 'Users with this permission can access gated content node/eventseries/eventinstance pages.'

--- a/openy_gated_content.services.yml
+++ b/openy_gated_content.services.yml
@@ -1,0 +1,6 @@
+services:
+  openy_gated_content.subscriber:
+    class: '\Drupal\openy_gated_content\EventSubscriber\GatedContentSubscriber'
+    arguments: ['@current_user']
+    tags:
+      - { name: 'event_subscriber' }

--- a/src/EventSubscriber/GatedContentSubscriber.php
+++ b/src/EventSubscriber/GatedContentSubscriber.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Drupal\openy_gated_content\EventSubscriber;
+
+use Drupal\Core\Session\AccountProxyInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Gated contend entities pages access checking.
+ */
+class GatedContentSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The current active user.
+   *
+   * @var \Drupal\Core\Session\AccountProxyInterface
+   */
+  protected $currentUser;
+
+  /**
+   * Constructs a GatedContent Event Subscriber.
+   *
+   * @param \Drupal\Core\Session\AccountProxyInterface $user
+   *   The current active user.
+   */
+  public function __construct(AccountProxyInterface $user) {
+    $this->currentUser = $user;
+  }
+
+  /**
+   * Check Access to gated contend entities pages.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+   *   The GetResponseEvent to process.
+   */
+  public function accessCheck(GetResponseEvent $event) {
+    $request = $event->getRequest();
+    $route_name = $request->get('_route');
+    $protected_routes = [
+      'entity.node.canonical',
+      'entity.eventseries.canonical',
+      'entity.eventinstance.canonical',
+    ];
+
+    if (!in_array($route_name, $protected_routes)) {
+      return;
+    }
+
+    $route_object = NULL;
+    switch ($route_name) {
+      case 'entity.node.canonical':
+        $route_object = $request->get('node');
+        break;
+
+      case 'entity.eventseries.canonical':
+        $route_object = $request->get('eventseries');
+        break;
+
+      case 'entity.eventinstance.canonical':
+        $route_object = $request->get('eventinstance');
+        break;
+    }
+
+    $entity_types = ['gc_video', 'live_stream'];
+    if (!$route_object || !in_array($route_object->getType(), $entity_types)) {
+      return;
+    }
+
+    if (!$this->currentUser->hasPermission('view gated content entities pages')) {
+      throw new AccessDeniedHttpException('This page is not available.');
+    }
+
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    // We need to have a priority of 31 or less to have the route available.
+    $events[KernelEvents::REQUEST][] = ['accessCheck', 30];
+    return $events;
+  }
+
+}


### PR DESCRIPTION
Task - https://fivejars.atlassian.net/browse/VYMCA-19

**Steps for review:**

- [ ] Login as admin
- [ ] Create live_stream event
- [ ] Check that you can access video, event series, event instance pages as authenticated user
- [ ] Check this pages as anonymous - access should be closed
- [ ] Open gated content
- [ ] Check that it works fine and videos and livestream visible