### PR TITLE
[VYMCA-36] Add support of Vimeo live streams

### DIFF
--- a/js/gated-content/src/components/MediaPlayer.vue
+++ b/js/gated-content/src/components/MediaPlayer.vue
@@ -36,20 +36,13 @@ export default {
     vimeoOptions() {
       const options = {
         videoId: this.media.field_media_video_id,
+        'video-url': this.media.field_media_video_embed_field,
         playerWidth: undefined,
         playerHeight: undefined,
         options: {
           responsive: true,
         },
       };
-
-      if (/https:\/\/vimeo\.com\/\d+\/[a-z0-9]+/i.test(this.media.field_media_video_embed_field)
-        || /https:\/\/vimeo\.com\/event\/\d+/i.test(this.media.field_media_video_embed_field)
-      ) {
-        // In case we have private video or event - set video-url option.
-        // Example of private url - https://vimeo.com/426932693/cfbe98b981
-        options['video-url'] = this.media.field_media_video_embed_field;
-      }
 
       return options;
     },

--- a/js/gated-content/src/components/MediaPlayer.vue
+++ b/js/gated-content/src/components/MediaPlayer.vue
@@ -1,7 +1,11 @@
 <template>
   <div>
     <LazyYoutubeVideo ref="youtube-player" v-if="source === 'youtube'" :src="youtubeSrc"/>
-    <vueVimeoPlayer ref="vimeo-player" v-if="source === 'vimeo'" v-bind="vimeoOptions"/>
+    <vueVimeoPlayer
+      ref="vimeo-player"
+      v-if="source === 'vimeo' || source === 'vimeo_event'"
+      v-bind="vimeoOptions"
+    />
   </div>
 </template>
 
@@ -39,8 +43,10 @@ export default {
         },
       };
 
-      if (/https:\/\/vimeo\.com\/\d+\/[a-z0-9]+/i.test(this.media.field_media_video_embed_field)) {
-        // In case we have private video - set video-url option.
+      if (/https:\/\/vimeo\.com\/\d+\/[a-z0-9]+/i.test(this.media.field_media_video_embed_field)
+        || /https:\/\/vimeo\.com\/event\/\d+/i.test(this.media.field_media_video_embed_field)
+      ) {
+        // In case we have private video or event - set video-url option.
         // Example of private url - https://vimeo.com/426932693/cfbe98b981
         options['video-url'] = this.media.field_media_video_embed_field;
       }

--- a/src/Plugin/video_embed_field/Provider/VimeoEvent.php
+++ b/src/Plugin/video_embed_field/Provider/VimeoEvent.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Drupal\openy_gated_content\Plugin\video_embed_field\Provider;
+
+use Drupal\Component\Serialization\Json;
+use Drupal\video_embed_field\ProviderPluginBase;
+
+/**
+ * A Vimeo Event provider plugin.
+ *
+ * In Open Y used video_embed_field, maybe in future it will be replaced by
+ * core oEmbed.
+ *
+ * @see https://www.drupal.org/project/video_embed_field/issues/2997799
+ * @see https://developer.vimeo.com/api/oembed/rles#embedding-a-recurring-live-event
+ *
+ * @VideoEmbedProvider(
+ *   id = "vimeo_event",
+ *   title = @Translation("Vimeo Event")
+ * )
+ */
+class VimeoEvent extends ProviderPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function renderEmbedCode($width, $height, $autoplay) {
+    $iframe = [
+      '#type' => 'video_embed_iframe',
+      '#provider' => 'vimeo_event',
+      '#url' => sprintf('https://vimeo.com/event/%s/embed', $this->getVideoId()),
+      '#query' => [
+        'autoplay' => $autoplay,
+      ],
+      '#attributes' => [
+        'width' => $width,
+        'height' => $height,
+        'frameborder' => '0',
+        'allowfullscreen' => 'allowfullscreen',
+      ],
+    ];
+    if ($time_index = $this->getTimeIndex()) {
+      $iframe['#fragment'] = sprintf('t=%s', $time_index);
+    }
+    return $iframe;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getRemoteThumbnailUrl() {
+    $data = $this->oEmbedData();
+    // TODO: maybe better to use custom image instead vimeo default.
+    return isset($data['thumbnail_url']) ? $data['thumbnail_url'] : 'https://i.vimeocdn.com/video/default_852x480.jpeg';
+  }
+
+  /**
+   * Get the vimeo event oEmbed data.
+   *
+   * @return array
+   *   An array of data from the oEmbed endpoint.
+   */
+  protected function oEmbedData() {
+    $url = 'https://vimeo.com/api/oembed.json?url=' . $this->getInput();
+    $response = \Drupal::service('http_client')->get($url, [
+      'headers' => [
+        // For private events we need to add HTTP_REFERER header.
+        'Referer' => $_SERVER['HTTP_REFERER'],
+      ],
+    ]);
+    $content = (string) $response->getBody();
+    return Json::decode($content);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getIdFromInput($input) {
+    preg_match('/^https?:\/\/vimeo\.com\/event\/(?<id>[0-9]*)?$/', $input, $matches);
+    return isset($matches['id']) ? $matches['id'] : FALSE;
+  }
+
+  /**
+   * Get the time index from the URL.
+   *
+   * @return string|false
+   *   A time index parameter to pass to the frame or FALSE if none is found.
+   */
+  protected function getTimeIndex() {
+    preg_match('/\#t=(?<time_index>(\d+)s)$/', $this->input, $matches);
+    return isset($matches['time_index']) ? $matches['time_index'] : FALSE;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getName() {
+    $data = $this->oEmbedData();
+    return $data['title'];
+  }
+
+}


### PR DESCRIPTION
**Note:** the event will work correctly if the domain in a whitelist, for now, here only **rose.openy.docksal**, I will add build domain when it will be ready. If on local you use something except for **rose.openy.docksal**, ping me and I will add your domain too

**Steps for review:**

- [ ] Login as admin
- [ ] Create an event with this media - https://vimeo.com/event/98281
- [ ] Check that it works and displayed correctly
- [ ] For some reason it use default thumbnail in any case, so in teasers, you will see something like this:

![Screenshot from 2020-06-11 12-59-44](https://user-images.githubusercontent.com/13733670/84372217-778ee200-abe3-11ea-957a-3e02cdbdd3f8.png)

- [ ] On the event page you will see this:

![Screenshot from 2020-06-11 13-00-17](https://user-images.githubusercontent.com/13733670/84372293-92f9ed00-abe3-11ea-9d40-8aadbe46a6f5.png)

Note: video iframe size will be fixed later

