### PR TITLE
[VYMCA-77] Display compatible video host sources in video field widget

### DIFF
--- a/modules/openy_gc_storage/openy_gc_storage.module
+++ b/modules/openy_gc_storage/openy_gc_storage.module
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * @file
+ * Contains openy_gc_storage.module.
+ */
+
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Implements hook_field_widget_form_alter().
+ */
+function openy_gc_storage_field_widget_form_alter(&$element, FormStateInterface $form_state, $context) {
+  $field_definition = $context['items']->getFieldDefinition();
+  if ($field_definition->getType() == 'video_embed_field') {
+    $allowed_providers = $field_definition->getSetting('allowed_providers');
+    $providers = \Drupal::service('video_embed_field.provider_manager')->loadDefinitionsFromOptionList($allowed_providers);
+    $element['value']['#description'] = t('Allowed providers:');
+    $providers_list = [];
+    foreach ($providers as $provider) {
+      $providers_list[] = $provider['title']->render();
+    }
+    sort($providers_list);
+    // Add Allowed providers list to description.
+    $element['value']['#description'] .= ' ' . implode(', ', $providers_list);
+  }
+}


### PR DESCRIPTION
**Steps for review:**

- [x] Login as admin
- [x] Go to /admin/modules
- [x] Enable field UI module
- [x] Go to /node/add/gc_video
- [x] Click on "Select videos" in media field
- [x] Check that in **Video URL** field description you can see list of allowed providers

![Screenshot from 2020-09-17 14-06-11](https://user-images.githubusercontent.com/13733670/93462819-917d4680-f8ef-11ea-8576-a3ba7d801f77.png)

- [x] Go to /admin/structure/media/manage/video/fields/media.video.field_media_video_embed_field
- [x] Select several  **Allowed Providers** and save
- [x] Return to /node/add/gc_video
- [x] Click on "Select videos" in media field
- [x] Check that in description displayed only selected providers