### PR TITLE
Add recurring events series config and update hook.

### DIFF
--- a/modules/openy_gc_storage/config/install/recurring_events.eventseries.config.yml
+++ b/modules/openy_gc_storage/config/install/recurring_events.eventseries.config.yml
@@ -10,5 +10,5 @@ includes: 1
 enabled_fields: 'consecutive_recurring_date,daily_recurring_date,weekly_recurring_date,monthly_recurring_date,custom'
 threshold_warning: 1
 threshold_count: 200
-threshold_message: 'Saving this series will create up to @total event instances. This could result in memory exhaustion or site instability.'
+threshold_message: 'Saving this series will create up to @total event instances. This could result in memory exhaustion or site instability. Please try again with a smaller date range.'
 threshold_prevent_save: 0

--- a/modules/openy_gc_storage/config/install/recurring_events.eventseries.config.yml
+++ b/modules/openy_gc_storage/config/install/recurring_events.eventseries.config.yml
@@ -1,0 +1,14 @@
+interval: 15
+min_time: '04:00am'
+max_time: '11:45pm'
+date_format: 'F jS, Y h:iA'
+time_format: 'h:i A'
+days: 'monday,tuesday,wednesday,thursday,friday,saturday,sunday'
+limit: 10
+excludes: 1
+includes: 1
+enabled_fields: 'consecutive_recurring_date,daily_recurring_date,weekly_recurring_date,monthly_recurring_date,custom'
+threshold_warning: 1
+threshold_count: 200
+threshold_message: 'Saving this series will create up to @total event instances. This could result in memory exhaustion or site instability.'
+threshold_prevent_save: 0

--- a/modules/openy_gc_storage/openy_gc_storage.install
+++ b/modules/openy_gc_storage/openy_gc_storage.install
@@ -96,3 +96,17 @@ function openy_gc_storage_update_8004() {
     'field_inheritance.field_inheritance.eventinstance_virtual_meeting_category',
   ]);
 }
+
+/**
+ * Add recurring event series config to set interval and start time.
+ */
+function openy_gc_storage_update_8005() {
+  $config_dir = drupal_get_path('module', 'openy_gc_storage');
+  $config_dir .= '/config/install/';
+  // Update configuration.
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'recurring_events.eventseries.config',
+  ]);
+}


### PR DESCRIPTION
Fixes https://github.com/ymcatwincities/openy_gated_content/issues/38.

Two major changes are:
- interval: changed to 15 min.
- start time: changed to 4AM based on data from the Y-USA national db. That's the earliest open time of any YMCA branch.