### PR TITLE
[VYMCA-101] Hide category field on event view display due to an error

### DIFF
--- a/modules/openy_gc_storage/config/install/core.entity_view_display.eventinstance.live_stream.default.yml
+++ b/modules/openy_gc_storage/config/install/core.entity_view_display.eventinstance.live_stream.default.yml
@@ -13,19 +13,12 @@ dependencies:
     - recurring_events.eventinstance_type.live_stream
   module:
     - datetime_range
+    - text
 id: eventinstance.live_stream.default
 targetEntityType: eventinstance
 bundle: live_stream
 mode: default
 content:
-  category:
-    label: above
-    weight: 3
-    region: content
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
   date:
     label: above
     type: daterange_custom
@@ -43,16 +36,8 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: text_default
-  field_ls_category:
-    weight: 5
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-    type: entity_reference_label
-    region: content
   field_ls_featured:
-    weight: 12
+    weight: 10
     label: above
     settings:
       format: default
@@ -62,7 +47,7 @@ content:
     type: boolean
     region: content
   field_ls_host_name:
-    weight: 15
+    weight: 13
     label: above
     settings:
       link_to_entity: false
@@ -71,7 +56,7 @@ content:
     region: content
   field_ls_image:
     type: entity_reference_entity_view
-    weight: 13
+    weight: 11
     label: above
     settings:
       view_mode: default
@@ -79,7 +64,7 @@ content:
     third_party_settings: {  }
     region: content
   field_ls_level:
-    weight: 11
+    weight: 9
     label: above
     settings:
       link: true
@@ -88,7 +73,7 @@ content:
     region: content
   field_ls_media:
     type: entity_reference_entity_view
-    weight: 7
+    weight: 5
     label: above
     settings:
       view_mode: default
@@ -96,7 +81,7 @@ content:
     third_party_settings: {  }
     region: content
   field_ls_title:
-    weight: 14
+    weight: 12
     label: above
     settings:
       link_to_entity: false
@@ -105,7 +90,7 @@ content:
     region: content
   host_name:
     label: above
-    weight: 8
+    weight: 6
     region: content
     settings:
       link_to_entity: false
@@ -113,7 +98,7 @@ content:
     type: string
   image:
     label: above
-    weight: 9
+    weight: 7
     region: content
     settings:
       link: true
@@ -121,7 +106,7 @@ content:
     type: entity_reference_label
   instructor:
     label: above
-    weight: 10
+    weight: 8
     region: content
     settings:
       link_to_entity: false
@@ -129,7 +114,7 @@ content:
     type: string
   level:
     label: above
-    weight: 6
+    weight: 4
     region: content
     settings:
       link: true
@@ -145,7 +130,7 @@ content:
     type: entity_reference_label
   title:
     label: above
-    weight: 4
+    weight: 3
     region: content
     settings:
       link_to_entity: false
@@ -153,5 +138,7 @@ content:
     type: string
 hidden:
   body: true
+  category: true
   equipment: true
+  field_ls_category: true
   field_ls_equipment: true

--- a/modules/openy_gc_storage/config/install/core.entity_view_display.eventinstance.virtual_meeting.default.yml
+++ b/modules/openy_gc_storage/config/install/core.entity_view_display.eventinstance.virtual_meeting.default.yml
@@ -27,14 +27,6 @@ content:
     label: above
     settings: {  }
     third_party_settings: {  }
-  category:
-    type: entity_reference_label
-    weight: 10
-    region: content
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
   date:
     label: above
     type: daterange_custom
@@ -52,25 +44,9 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: text_default
-  field_ls_category:
-    type: entity_reference_label
-    weight: 5
-    region: content
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
-  field_ls_equipment:
-    type: entity_reference_label
-    weight: 14
-    region: content
-    label: above
-    settings:
-      link: true
-    third_party_settings: {  }
   field_ls_featured:
     type: boolean
-    weight: 6
+    weight: 5
     region: content
     label: above
     settings:
@@ -80,7 +56,7 @@ content:
     third_party_settings: {  }
   field_ls_host_name:
     type: string
-    weight: 7
+    weight: 6
     region: content
     label: above
     settings:
@@ -88,7 +64,7 @@ content:
     third_party_settings: {  }
   field_ls_image:
     type: entity_reference_label
-    weight: 8
+    weight: 7
     region: content
     label: above
     settings:
@@ -96,7 +72,7 @@ content:
     third_party_settings: {  }
   field_ls_level:
     type: entity_reference_label
-    weight: 15
+    weight: 12
     region: content
     label: above
     settings:
@@ -112,7 +88,7 @@ content:
     third_party_settings: {  }
   field_vm_link:
     type: link
-    weight: 9
+    weight: 8
     region: content
     label: above
     settings:
@@ -124,7 +100,7 @@ content:
     third_party_settings: {  }
   host_name:
     type: string
-    weight: 11
+    weight: 9
     region: content
     label: above
     settings:
@@ -132,7 +108,7 @@ content:
     third_party_settings: {  }
   image:
     type: entity_reference_label
-    weight: 12
+    weight: 10
     region: content
     label: above
     settings:
@@ -140,7 +116,7 @@ content:
     third_party_settings: {  }
   meeting_link:
     type: link
-    weight: 13
+    weight: 11
     region: content
     label: above
     settings:
@@ -159,5 +135,8 @@ content:
     third_party_settings: {  }
     type: string
 hidden:
+  category: true
   equipment: true
+  field_ls_category: true
+  field_ls_equipment: true
   level: true

--- a/modules/openy_gc_storage/openy_gc_storage.install
+++ b/modules/openy_gc_storage/openy_gc_storage.install
@@ -148,3 +148,18 @@ function openy_gc_storage_update_8006() {
   $role2_object->grantPermission('view eventseries entity');
   $role2_object->save();
 }
+
+/**
+ * Hide category field on event view display.
+ */
+function openy_gc_storage_update_8007() {
+  $config_dir = drupal_get_path('module', 'openy_gc_storage');
+  $config_dir .= '/config/install/';
+  // Import new configuration.
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'core.entity_view_display.eventinstance.live_stream.default',
+    'core.entity_view_display.eventinstance.virtual_meeting.default',
+  ]);
+}


### PR DESCRIPTION
Jira: https://fivejars.atlassian.net/browse/VYMCA-101
Basecamp: https://3.basecamp.com/3608022/buckets/17045978/todos/3164273439
Github: https://github.com/ymcatwincities/openy_gated_content/issues/53

**Details:**  

Field Inheritance throws an error in JSON API for multiple entity reference fields, because of this we used a different formatter, it works in JSON API but throws an error on the entity view page. To fix this we deleted this field from the output because the entity view page can be used only by admins and the edit form more useful to check all data.

**Steps for review**

- [ ] Login as admin
- [ ] Go to /admin/content/events/series
- [ ] Open any series
- [ ] Open any item from Events in this Series
- [ ] Check that you can't see an error


