### PR TITLE
Security issue fix for custom auth provider

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/README.md
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/README.md
@@ -44,13 +44,8 @@ destination fields and processors according to your needs.
 
 ### How to add custom validation logic for frontend app
 
-First of all you need to create new custom rest resource,
-you can extend existing GatedContentCustomAuthentication.php and add your
-custom logic (for example add password checking or use membership id
-instead of email).
-
-The second step - change API endpoint to your rest resource in plugin settings:
-- /admin/openy/openy-gc-auth/settings/provider/custom
+Alter `VirtualYCustomLoginForm` or subscribe on
+`gated_content_events_user_login` event.
 
 ### How to Run migration
 

--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Form/VirtualYCustomLoginForm.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Form/VirtualYCustomLoginForm.php
@@ -218,10 +218,9 @@ class VirtualYCustomLoginForm extends FormBase {
         $form_state->setRebuild(TRUE);
         return;
       }
-      else {
-        $this->gcUserAuthorizer->authorizeUser($user->getAccountName(), $mail);
-      }
     }
+
+    $this->gcUserAuthorizer->authorizeUser($user->getAccountName(), $mail);
   }
 
   /**

--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Form/VirtualYCustomLoginForm.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Form/VirtualYCustomLoginForm.php
@@ -10,6 +10,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Mail\MailManagerInterface;
 use Drupal\Core\TempStore\PrivateTempStoreFactory;
 use Drupal\Core\Url;
+use Drupal\openy_gc_auth\GCUserAuthorizer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
@@ -63,15 +64,31 @@ class VirtualYCustomLoginForm extends FormBase {
   protected $privateTempStore;
 
   /**
+   * The Gated Content User Authorizer.
+   *
+   * @var \Drupal\openy_gc_auth\GCUserAuthorizer
+   */
+  protected $gcUserAuthorizer;
+
+  /**
    * {@inheritdoc}
    */
-  public function __construct(RequestStack $requestStack, ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager, MailManagerInterface $mail_manager, FloodInterface $flood, PrivateTempStoreFactory $private_temp_store) {
+  public function __construct(
+    RequestStack $requestStack,
+    ConfigFactoryInterface $config_factory,
+    EntityTypeManagerInterface $entity_type_manager,
+    MailManagerInterface $mail_manager,
+    FloodInterface $flood,
+    PrivateTempStoreFactory $private_temp_store,
+    GCUserAuthorizer $gcUserAuthorizer
+  ) {
     $this->currentRequest = $requestStack->getCurrentRequest();
     $this->configFactory = $config_factory;
     $this->entityTypeManager = $entity_type_manager;
     $this->mailManager = $mail_manager;
     $this->flood = $flood;
     $this->privateTempStore = $private_temp_store->get('openy_gc_auth.provider.custom');
+    $this->gcUserAuthorizer = $gcUserAuthorizer;
   }
 
   /**
@@ -84,7 +101,8 @@ class VirtualYCustomLoginForm extends FormBase {
       $container->get('entity_type.manager'),
       $container->get('plugin.manager.mail'),
       $container->get('flood'),
-      $container->get('tempstore.private')
+      $container->get('tempstore.private'),
+      $container->get('openy_gc_auth.user_authorizer')
     );
   }
 
@@ -166,6 +184,21 @@ class VirtualYCustomLoginForm extends FormBase {
       ]));
       $this->flood->register('openy_gc_auth_custom.login', $flood_config->get('user_window'));
     }
+
+    // Restrict access to user 1 and users with roles except virtual_y*.
+    $user = reset($users);
+    $account_roles = $user->getRoles();
+    // Remove all virtual_y roles.
+    foreach ($account_roles as $id => $account_role) {
+      if (strstr($account_role, 'virtual_y') !== FALSE || $account_role == 'authenticated') {
+        unset($account_roles[$id]);
+      }
+    }
+    if ($user->id() == 1 || !empty($account_roles)) {
+      $form_state->setErrorByName('email', $this->t('This user is not allowed to login from this form.', [
+        '@mail' => $form_state->getValue('email'),
+      ]));
+    }
   }
 
   /**
@@ -186,15 +219,9 @@ class VirtualYCustomLoginForm extends FormBase {
         return;
       }
       else {
-        $user->setPassword(user_password());
-        $user->activate();
-        $user->save();
+        $this->gcUserAuthorizer->authorizeUser($user->getAccountName(), $mail);
       }
     }
-
-    user_login_finalize($user);
-    $path = $this->configFactory->get('openy_gated_content.settings')->get('virtual_y_url');
-    $form_state->setRedirectUrl(Url::fromUserInput($path));
   }
 
   /**

--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Form/VirtualYCustomLoginForm.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Form/VirtualYCustomLoginForm.php
@@ -189,12 +189,17 @@ class VirtualYCustomLoginForm extends FormBase {
     $user = reset($users);
     $account_roles = $user->getRoles();
     // Remove all virtual_y roles.
+    $has_virtual_role = FALSE;
     foreach ($account_roles as $id => $account_role) {
-      if (strstr($account_role, 'virtual_y') !== FALSE || $account_role == 'authenticated') {
+      if (strstr($account_role, 'virtual_y') !== FALSE) {
+        unset($account_roles[$id]);
+        $has_virtual_role = TRUE;
+      }
+      elseif ($account_role == 'authenticated') {
         unset($account_roles[$id]);
       }
     }
-    if ($user->id() == 1 || !empty($account_roles)) {
+    if (!$has_virtual_role || $user->id() == 1 || !empty($account_roles)) {
       $form_state->setErrorByName('email', $this->t('This user is not allowed to login from this form.', [
         '@mail' => $form_state->getValue('email'),
       ]));

--- a/modules/openy_gc_auth/src/GCUserAuthorizer.php
+++ b/modules/openy_gc_auth/src/GCUserAuthorizer.php
@@ -68,6 +68,7 @@ class GCUserAuthorizer {
       // Activate user if it's not.
       if (!$account->isActive()) {
         $account->activate();
+        $account->setPassword(user_password());
         $account->save();
       }
     }


### PR DESCRIPTION
**Steps for review:**

- [ ] Login as admin on '/user'
- [ ] Go to `/admin/openy/virtual-ymca/gc-auth-settings`
- [ ] Set `Custom provider` as active and save
- [ ] Logout
- [ ] Go to login form
- [ ] Try to login with `info@fivejars.com`
- [ ] Check that you can see error

![Screenshot from 2020-11-06 17-05-09](https://user-images.githubusercontent.com/13733670/98381348-6cd15f80-2052-11eb-82f7-436fe0801118.png)

- [ ] You can repeat steps with different users and roles (assign admin, editor roles, etc)
- [ ] The main requirement to log in - the user should have only authenticated and virtual_y_* roles, otherwise login will be restricted
- [ ] Check that for demo users it works fine (`adamk@verizon.net`, `joehall@live.com`) - note - after login, we have an email verification step, you can disable it in provider settings