### PR TITLE
Remove extra period from Daxko Barcode Provider

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_daxko_barcode/src/Controller/DaxkoBarcodeController.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_daxko_barcode/src/Controller/DaxkoBarcodeController.php
@@ -148,7 +148,7 @@ class DaxkoBarcodeController extends ControllerBase {
           case 'duplicate_barcode':
           case 'invalid':
 
-            $this->messenger->addError($config->get("message_{$status}") . '. ' . $config->get('message_help'));
+            $this->messenger->addError($config->get("message_{$status}") . ' ' . $config->get('message_help'));
             return new RedirectResponse($this->configFactory->get('openy_gated_content.settings')->get('virtual_y_login_url'));
         }
 


### PR DESCRIPTION
All of the [default messages](https://github.com/fivejars/openy_gated_content/blob/master/modules/openy_gc_auth/modules/openy_gc_auth_daxko_barcode/config/install/openy_gc_auth.provider.daxko_barcode.yml) have a period at the end, so this period between the two strings is causing duplication. Let's get rid of it.

![VIRTUAL_Y_Login___YMCA_of_Capital_District_-__Private_Browsing_](https://user-images.githubusercontent.com/238201/99124047-022aa180-25c7-11eb-91d2-70af22dcc21d.png)

