### PR TITLE
Exclude virtual_ymca_editor from category access check

### DIFF
--- a/src/Controller/CategoriesController.php
+++ b/src/Controller/CategoriesController.php
@@ -13,6 +13,8 @@ use Symfony\Component\HttpFoundation\JsonResponse;
  */
 class CategoriesController extends ControllerBase implements ContainerInjectionInterface {
 
+  const EDITOR_ROLE = 'virtual_ymca_editor';
+
   /**
    * The current active database's master connection.
    *
@@ -66,7 +68,7 @@ class CategoriesController extends ControllerBase implements ContainerInjectionI
     $query->condition('t.vid', 'gc_category');
     $query->condition('tf.status', 1);
 
-    if (!empty($y_roles)) {
+    if (!empty($y_roles) && !in_array(self::EDITOR_ROLE, $y_roles)) {
       $query->leftJoin('node_field_data', 'nd', 'n.entity_id = nd.nid');
       $or_group = $query->orConditionGroup();
       foreach ($y_roles as $role) {


### PR DESCRIPTION
**Related Issue/Ticket:**

https://github.com/ymcatwincities/openy_gated_content/issues/77

## Steps to test:

- [ ] log in to https://sandbox-carnation-std-virtual-y.openy.org/ and create a user with the "Virtual YMCA Editor" role
- [ ] observe that as Administrator and Member, you can see these pages:
  - [ ] /virtual-ymca#/categories/blog
  - [ ] /virtual-ymca#/categories/video
- [ ] log in as the Editor
- [ ] Observe the above pages are empty, with no error or message.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [x] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA team in Slack
