### PR TITLE
[VYMCA-108] Disable /user/{id}/edit page for virtual y users

### DIFF
--- a/openy_gated_content.services.yml
+++ b/openy_gated_content.services.yml
@@ -7,3 +7,7 @@ services:
   openy_gated_content.user_service:
     class: '\Drupal\openy_gated_content\GCUserService'
     arguments: ['@entity_type.manager']
+  openy_gated_content.route_subscriber:
+    class: '\Drupal\openy_gated_content\EventSubscriber\RouteSubscriber'
+    tags:
+      - { name: event_subscriber }

--- a/src/EditUserAccountAccessCheck.php
+++ b/src/EditUserAccountAccessCheck.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Drupal\openy_gated_content;
+
+use Drupal\Core\Access\AccessResult;
+use Drupal\Core\Routing\Access\AccessInterface;
+use Drupal\Core\Session\AccountInterface;
+
+/**
+ * Class Edit User Account Access Check.
+ *
+ * @package Drupal\openy_gated_content
+ */
+class EditUserAccountAccessCheck implements AccessInterface {
+
+  /**
+   * Checks access for editing user account.
+   *
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   The user account that is to be edited.
+   * @param \Drupal\Core\Session\AccountInterface $account
+   *   User account that is from the current session.
+   *
+   * @return \Drupal\Core\Access\AccessResult
+   *   The access result.
+   */
+  public function access(AccountInterface $user, AccountInterface $account) {
+    $roles = $account->getRoles();
+    foreach ($roles as $role) {
+      if (strpos($role, 'virtual_y_') !== FALSE || $role == 'virtual_y') {
+        return AccessResult::forbidden()->cachePerUser();
+      }
+    }
+    return AccessResult::allowedIf($user->id() === $account->id()
+      || $account->hasPermission('administer users'));
+  }
+
+}

--- a/src/EventSubscriber/RouteSubscriber.php
+++ b/src/EventSubscriber/RouteSubscriber.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\openy_gated_content\EventSubscriber;
+
+use Drupal\Core\Routing\RouteSubscriberBase;
+use Symfony\Component\Routing\RouteCollection;
+
+/**
+ * Listens to the dynamic route events.
+ */
+class RouteSubscriber extends RouteSubscriberBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function alterRoutes(RouteCollection $collection) {
+    // Always check with custom access to '/user/{uid}/edit'.
+    if ($route = $collection->get('entity.user.edit_form')) {
+      $route->setRequirement('_custom_access', '\\Drupal\\openy_gated_content\\EditUserAccountAccessCheck::access');
+    }
+  }
+
+}


### PR DESCRIPTION
https://fivejars.atlassian.net/browse/VYMCA-108
https://3.basecamp.com/3608022/buckets/17045978/todos/3262514567

## Steps to test:

- [ ] Log in to the VY as non-admin
- [ ] Go to /user
- [ ] Ensure you have no "Edit" tab
- [ ] Check that access to /user/{ID}/edit is denied
- [ ] Log in as admin user
- [ ] Ensure that changes haven't been applied for privileged users.