### PR TITLE
Train credentials at Daxko

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_daxko_sso/src/Controller/DaxkoLinkController.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_daxko_sso/src/Controller/DaxkoLinkController.php
@@ -87,7 +87,13 @@ class DaxkoLinkController extends ControllerBase {
       $plugin_config = $this->configFactory->get('openy_gc_auth.provider.daxko_sso');
       $backlinkUrl = $request->getSchemeAndHttpHost() . $plugin_config->get('redirect_url');
 
-      $daxkoSSORedirectLink = 'https://operations.daxko.com/online/auth'
+      $operationsUrl = 'https://operations.daxko.com/online/auth';
+      // Check if we have train api.
+      if (strpos($config->get('base_uri'), 'train') !== FALSE) {
+        $operationsUrl = 'https://operations-train.daxko.com/online/auth';
+      }
+
+      $daxkoSSORedirectLink = $operationsUrl
         . '?response_type=code&scope=client:'
         . $config->get('client_id') . '+member:basic_info&state='
         . md5($request->getSchemeAndHttpHost())


### PR DESCRIPTION
We have a bug when the user is always redirected to the operations.daxko.com
In this case we cant use train credentials.
I've added logic that fixes it.

## Steps to test:

- [ ] Enable and configure train credentials for daxko
- [ ] Enable daxko sso auth method
- [ ] Check that user is redirected to operations-train instead of operations.daxko.com

