### PR TITLE
Fix reclique logger

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique/openy_gc_auth_reclique.services.yml
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique/openy_gc_auth_reclique.services.yml
@@ -6,4 +6,4 @@ services:
       - { name: 'event_subscriber' }
   openy_gc_auth_reclique_client:
     class: '\Drupal\openy_gc_auth_reclique\RecliqueClientService'
-    arguments: ['@config.factory', '@http_client']
+    arguments: ['@logger.factory','@config.factory', '@http_client']

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique/openy_gc_auth_reclique.services.yml
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique/openy_gc_auth_reclique.services.yml
@@ -6,4 +6,4 @@ services:
       - { name: 'event_subscriber' }
   openy_gc_auth_reclique_client:
     class: '\Drupal\openy_gc_auth_reclique\RecliqueClientService'
-    arguments: ['@logger.factory','@config.factory', '@http_client']
+    arguments: ['@logger.factory', '@config.factory', '@http_client']

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique/src/RecliqueClientService.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique/src/RecliqueClientService.php
@@ -37,8 +37,8 @@ class RecliqueClientService {
   /**
    * RecliqueClientService constructor.
    *
-   * @param LoggerChannelFactory $loggerFactory
-   *   \Drupal\Core\Logger\LoggerChannelFactory instance.
+   * @param \Drupal\Core\Logger\LoggerChannelFactory $loggerFactory
+   *   LoggerChannelFactory instance.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   ConfigFactoryInterface instance.
    * @param \GuzzleHttp\Client $client

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique/src/RecliqueClientService.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique/src/RecliqueClientService.php
@@ -3,6 +3,7 @@
 namespace Drupal\openy_gc_auth_reclique;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelFactory;
 use GuzzleHttp\Client;
 
 /**
@@ -11,6 +12,13 @@ use GuzzleHttp\Client;
  * @package Drupal\openy_gc_auth_reclique
  */
 class RecliqueClientService {
+
+  /**
+   * Logger Factory.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelFactory
+   */
+  protected $loggerFactory;
 
   /**
    * The config factory.
@@ -29,12 +37,15 @@ class RecliqueClientService {
   /**
    * RecliqueClientService constructor.
    *
+   * @param LoggerChannelFactory $loggerFactory
+   *   LoggerChannelFactory instance.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   ConfigFactoryInterface instance.
    * @param \GuzzleHttp\Client $client
    *   Guzzle client.
    */
-  public function __construct(ConfigFactoryInterface $configFactory, Client $client) {
+  public function __construct(LoggerChannelFactory $loggerFactory, ConfigFactoryInterface $configFactory, Client $client) {
+    $this->loggerFactory = $loggerFactory->get('openy_gc_auth_reclique');
     $this->configFactory = $configFactory;
     $this->client = $client;
   }
@@ -72,7 +83,7 @@ class RecliqueClientService {
       }
     }
     catch (\Exception $e) {
-      $this->logger('openy_gated_content')->error($e->getMessage());
+      $this->loggerFactory->error($e->getMessage());
     }
     return [];
   }

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique/src/RecliqueClientService.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique/src/RecliqueClientService.php
@@ -83,7 +83,7 @@ class RecliqueClientService {
       }
     }
     catch (\Exception $e) {
-      $this->loggerFactory->error($e->getMessage());
+      $this->logger->error($e->getMessage());
     }
     return [];
   }

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique/src/RecliqueClientService.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique/src/RecliqueClientService.php
@@ -18,7 +18,7 @@ class RecliqueClientService {
    *
    * @var \Drupal\Core\Logger\LoggerChannelFactory
    */
-  protected $loggerFactory;
+  protected $logger;
 
   /**
    * The config factory.

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique/src/RecliqueClientService.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique/src/RecliqueClientService.php
@@ -45,7 +45,7 @@ class RecliqueClientService {
    *   Guzzle client.
    */
   public function __construct(LoggerChannelFactory $loggerFactory, ConfigFactoryInterface $configFactory, Client $client) {
-    $this->loggerFactory = $loggerFactory->get('openy_gc_auth_reclique');
+    $this->logger = $loggerFactory->get('openy_gc_auth_reclique');
     $this->configFactory = $configFactory;
     $this->client = $client;
   }

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique/src/RecliqueClientService.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique/src/RecliqueClientService.php
@@ -38,7 +38,7 @@ class RecliqueClientService {
    * RecliqueClientService constructor.
    *
    * @param LoggerChannelFactory $loggerFactory
-   *   LoggerChannelFactory instance.
+   *   \Drupal\Core\Logger\LoggerChannelFactory instance.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   ConfigFactoryInterface instance.
    * @param \GuzzleHttp\Client $client


### PR DESCRIPTION
**Related Issue/Ticket:**

https://github.com/ymcatwincities/openy_gated_content/issues/84

## Steps to test:

- Enable the "Open Y Virtual YMCA Auth ReClique" module for a site using ReClique CORE crm (http://northpennymca-azure-stage.y.org/)
- Configure the module with API user credentials, and use the default Staging endpoint from Reclique
- Attempt member login using any email address - for this repro a legit member email is not required.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [X] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [X] This change does not contain front-end fixes.
- [X] I have flagged this PR "Needs Review" or pinged the VY devs/QA team in Slack
