### PR TITLE
[VYMCA-114] Add require_email_verification setting

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/README.md
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/README.md
@@ -14,46 +14,38 @@ Member ID,Member First Name,Primary Member,Member Email,Package Name,Package Sit
 ```
 
 If you have different structure or set of fields, you need to:
-- Override base fields for gc_auth_custom_user entity
-- Modify migration
-- Modify validation logic for frontend application
-
-### How to override base fields
-If your users data have different fields, you can use
-hook_entity_base_field_info_alter to add them to AuthCustomUser entity.
-
-Example:
-
-```php
-function hook_entity_base_field_info_alter(&$fields, $entity_type) {
-
-  // Alter the mymodule_text field to use a custom class.
-  if ($entity_type->id() == 'gc_auth_custom_user') {
-    $fields['password'] = BaseFieldDefinition::create('string')
-      ->setLabel(t('Password'))
-      ->setDescription(t('User password.'));
-  }
-}
-
-```
+- Add fields to user entity (`/admin/config/people/accounts/fields`)
+- Modify migration `migrate_plus.migration.gc_auth_custom_users.yml`
+- Modify validation logic by altering `VirtualYCustomLoginForm.php`
 
 ### How to Modify migration
 For this you can change content of config
-migrate_plus.migration.gc_auth_custom_users.yml. You can modify
+`migrate_plus.migration.gc_auth_custom_users.yml`. You can modify
 destination fields and processors according to your needs.
-
-### How to add custom validation logic for frontend app
-
-Alter `VirtualYCustomLoginForm` or subscribe on
-`gated_content_events_user_login` event.
 
 ### How to Run migration
 
+You can find all links on
+`/admin/openy/virtual-ymca/gc-auth-settings/provider/custom`
+page in `Migration settings` section.
+
 From UI:
 - Login as admin
-- Go to /admin/openy/openy-gc-auth/settings/provider/custom/import_csv
-- Select migration group to run
-- Run batch
+- For SCV file upload:
+  - Go to `/admin/openy/openy-gc-auth/settings/provider/custom/upload-csv`
+  - Upload file
+  - Press submit button.
+  - After this file will be uploaded to
+    `'private://gc_auth/import/gc_auth_custom_users.csv'`
+- Run migration:
+  - Go to
+`/admin/structure/migrate/manage/gc_auth/migrations/gc_auth_custom_users/execute`
+  - Select `Operation` group to run (by default - ` Import`)
+  - In `Additional execution options` you can set `Sync` option if you want to
+    delete users from the site that not exist in CSV file (This related
+    only to users that was imported previous time).
+  - Press `Execute`
+  - Wait until batch finish
 
 From drush:
 ```shell script
@@ -74,11 +66,13 @@ drush mim gc_auth_custom_users --sync=TRUE
 
 ### How to upload source file
 
-You can upload source file directly to `private://gc_auth/import/gc_auth_custom_users.csv`.
+You can upload source file directly to
+`private://gc_auth/import/gc_auth_custom_users.csv`.
 
 OR
 
-You can upload file from the Drupal UI in Migration Group settings at `/admin/structure/migrate/manage/gc_auth`. If you upload a file from the UI it must be entitled `gc_auth_custom_users.csv` exactly.
+You can upload file from the Drupal UI at
+`/admin/openy/openy-gc-auth/settings/provider/custom/upload-csv`.
 
 ## Notes:
 
@@ -100,3 +94,9 @@ See https://www.drupal.org/project/migrate_tools/issues/2809433#comment-13362844
 
 To fix this - apply a patch for migrate_tools
 patches/migrate_tools_sync_option_for_drush8.patch
+
+
+### Migrate tools 5.0 and sync option from UI
+
+For the ability to use sync option from UI in Migrate tools 5.0 we need to apply
+a custom patch, see `composer.json` of this module.

--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/config/install/openy_gc_auth.provider.custom.yml
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/config/install/openy_gc_auth.provider.custom.yml
@@ -1,5 +1,6 @@
 enable_recaptcha: 1
 enable_email_verification: 1
+require_email_verification: 0
 email_verification_link_life_time: '14400'
 email_verification_text: 'Hello! <br> You’re just one step away from accessing your Virtual YMCA. Please open the link below to begin enjoying YMCA content made exclusively for members like you.'
 verification_message: 'We have sent a verification link to the email address you provided. Please open this link and activate your account. If you do not receive an email, please try again or contact us at XXX-XXX-XXXX to ensure we have the correct email on file for your membership.'

--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/openy_gc_auth_custom.install
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/openy_gc_auth_custom.install
@@ -126,3 +126,13 @@ function openy_gc_auth_custom_update_8006() {
     'migrate_plus.migration_group.gc_auth',
   ]);
 }
+
+/**
+ * Add value for require_email_verification setting.
+ */
+function openy_gc_auth_custom_update_8007(&$sandbox) {
+  \Drupal::configFactory()
+    ->getEditable('openy_gc_auth.provider.custom')
+    ->set('require_email_verification', 0)
+    ->save();
+}

--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Form/VirtualYCustomLoginForm.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Form/VirtualYCustomLoginForm.php
@@ -217,8 +217,11 @@ class VirtualYCustomLoginForm extends FormBase {
       ->getStorage('user')
       ->loadByProperties(['mail' => $mail]);
     $user = reset($users);
-    if (!$user->isActive()) {
-      if ($provider_config->get('enable_email_verification')) {
+
+    if ($provider_config->get('enable_email_verification')) {
+      if ($provider_config->get('require_email_verification') || !$user->isActive()) {
+        // Send email verification if user is blocked or if enabled required
+        // email verification.
         $this->sendEmailVerification($user, $provider_config, $mail);
         $form_state->setValue('verified', TRUE);
         $form_state->setRebuild(TRUE);

--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Plugin/GCIdentityProvider/Custom.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Plugin/GCIdentityProvider/Custom.php
@@ -26,6 +26,7 @@ class Custom extends GCIdentityProviderPluginBase {
     return [
       'enable_recaptcha' => TRUE,
       'enable_email_verification' => TRUE,
+      'require_email_verification' => FALSE,
       'email_verification_link_life_time' => self::DEFAULT_LINK_LIFE_TIME,
       'email_verification_text' => 'Hello! <br> You’re just one step away from accessing your Virtual YMCA. Please open the link below to begin enjoying YMCA content made exclusively for members like you.',
       'verification_message' => 'We have sent a verification link to the email address you provided. Please open this link and activate your account. If you do not receive an email, please try again or contact us at XXX-XXX-XXXX to ensure we have the correct email on file for your membership.',
@@ -57,6 +58,13 @@ class Custom extends GCIdentityProviderPluginBase {
       '#description' => $this->t('Set to TRUE if you want enable one-time login link sending to user email for verification.'),
       '#type' => 'checkbox',
       '#default_value' => $config['enable_email_verification'],
+    ];
+
+    $form['verification']['require_email_verification'] = [
+      '#title' => $this->t('Require Email verification'),
+      '#description' => $this->t('Set to TRUE if you want to use email verification on each user login. If FALSE - email verification will be used only on first login for account activation.'),
+      '#type' => 'checkbox',
+      '#default_value' => $config['require_email_verification'],
     ];
 
     $form['verification']['email_verification_link_life_time'] = [
@@ -135,7 +143,7 @@ class Custom extends GCIdentityProviderPluginBase {
       $this->configuration['enable_recaptcha'] = $form_state->getValue('enable_recaptcha');
       $this->configuration['api_endpoint'] = $form_state->getValue('api_endpoint');
       $this->configuration['enable_email_verification'] = $form_state->getValue('enable_email_verification');
-      $this->configuration['email_verification_api_endpoint'] = $form_state->getValue('email_verification_api_endpoint');
+      $this->configuration['require_email_verification'] = $form_state->getValue('require_email_verification');
       $this->configuration['email_verification_link_life_time'] = $form_state->getValue('email_verification_link_life_time');
       $this->configuration['email_verification_text'] = !empty($form_state->getValue('email_verification_text')) ? $form_state->getValue('email_verification_text')['value'] : '';
       $this->configuration['verification_message'] = !empty($form_state->getValue('verification_message')) ? $form_state->getValue('verification_message')['value'] : '';

--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Plugin/GCIdentityProvider/Custom.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Plugin/GCIdentityProvider/Custom.php
@@ -58,6 +58,9 @@ class Custom extends GCIdentityProviderPluginBase {
       '#description' => $this->t('Set to TRUE if you want enable one-time login link sending to user email for verification.'),
       '#type' => 'checkbox',
       '#default_value' => $config['enable_email_verification'],
+      '#attributes' => [
+        'name' => 'enable_email_verification',
+      ],
     ];
 
     $form['verification']['require_email_verification'] = [
@@ -65,6 +68,11 @@ class Custom extends GCIdentityProviderPluginBase {
       '#description' => $this->t('Set to TRUE if you want to use email verification on each user login. If FALSE - email verification will be used only on first login for account activation.'),
       '#type' => 'checkbox',
       '#default_value' => $config['require_email_verification'],
+      '#states' => [
+        'visible' => [
+          ':input[name="enable_email_verification"]' => ['checked' => TRUE],
+        ],
+      ],
     ];
 
     $form['verification']['email_verification_link_life_time'] = [


### PR DESCRIPTION
**Related Issue/Ticket:**

https://fivejars.atlassian.net/browse/VYMCA-114

## Steps to test:

- [ ] Login as admin
- [ ] Go to `/admin/openy/virtual-ymca/gc-auth-settings`
- [ ] Set `Custom provider` as selected provider and save
- [ ] Open site in an anonymous tab
- [ ] Login as `nelson@gmail.com`
- [ ] Check that you can see the verification message
- [ ] Open mailhog - 
- [ ] Try to login by a link from this message
- [ ] Logout
- [ ] Login as `nelson@gmail.com` one more time
- [ ] Check that you logged in without confirmation
- [ ] Return to the tab with an admin session
- [ ] Go to `Custom provider` settings page `/admin/openy/virtual-ymca/gc-auth-settings/provider/custom`
- [ ] Check that you can see the new `Require Email verification` checkbox in the `Email verification` section (Should be disabled by default)

![screenshot-carnation openy docksal-2020 12 21-18_01_44](https://user-images.githubusercontent.com/13733670/102796411-e9c45880-43b6-11eb-8681-826c4cd52752.png)

- [ ] Set `Require Email verification` checkbox and save
- [ ] Open site in an anonymous tab
- [ ] Try to login as `nelson@gmail.com` several times
- [ ] Check that verification asked on each login
- [ ] Try to test with a different user (For example `johndoe@test.com`)
- [ ] Check that verification asked on each login
- [ ] Return to the tab with an admin session
- [ ] Go to `Custom provider` settings page `/admin/openy/virtual-ymca/gc-auth-settings/provider/custom`
- [ ] Disable `Enable Email verification` and save
- [ ] Open site in an anonymous tab
- [ ] Try to login as `adamk@verizon.net`
- [ ] Check that you can log in as a blocked user without email verification (By default created VY users like `adamk@verizon.net` are blocked)
