### PR TITLE
association number field allow max 4 character

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_yusa/src/Plugin/GCIdentityProvider/YUSA.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_yusa/src/Plugin/GCIdentityProvider/YUSA.php
@@ -109,7 +109,7 @@ class YUSA extends GCIdentityProviderPluginBase {
       '#description' => $this->t('This is usually 4 digits.'),
       '#default_value' => $config['association_number'],
       '#required' => TRUE,
-      '#maxlength'=> 4,
+      '#maxlength' => 4,
     ];
 
     $form['verification_url'] = [

--- a/modules/openy_gc_auth/modules/openy_gc_auth_yusa/src/Plugin/GCIdentityProvider/YUSA.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_yusa/src/Plugin/GCIdentityProvider/YUSA.php
@@ -109,6 +109,7 @@ class YUSA extends GCIdentityProviderPluginBase {
       '#description' => $this->t('This is usually 4 digits.'),
       '#default_value' => $config['association_number'],
       '#required' => TRUE,
+      '#maxlength'=> 4,
     ];
 
     $form['verification_url'] = [


### PR DESCRIPTION
**Related Issue/Ticket:**

https://dev.azure.com/y-usa/Y-Cloud/_workitems/edit/23622

## Steps to test:
- [x] Enable the Open Y Virtual YMCA Auth Y-USA module
- [x] Go to the configuration page at Virtual Y > GC Auth > YUSA
- [x] The YUSA settings are at /admin/openy/virtual-ymca/gc-auth-settings/provider/yusa
- [ ] Y-USA provider configuration form will show, check and verify 'Association field' with with put some character, it should not more than 4 characters.
- [ ] Finally observe the issue is resolved.

## Quality checks:

- [ ]  Go to the configuration page, the YUSA settings are at /admin/openy/virtual-ymca/gc-auth-settings/provider/yusa
- [ ] Y-USA provider configuration form will show, check and verify 'Association field' with with put some character, it should not more than 4 characters.
