### PR TITLE
Deleted openy_gc_auth_example dependency

### DIFF
--- a/modules/openy_gc_demo/openy_gc_demo.info.yml
+++ b/modules/openy_gc_demo/openy_gc_demo.info.yml
@@ -15,5 +15,4 @@ dependencies:
   - drupal:openy_gated_content
   - drupal:openy_gc_storage
   - drupal:openy_gc_auth_example
-  - drupal:openy_gc_auth_custom
   - drupal:openy_demo_tcolor


### PR DESCRIPTION
**Related Issue/Ticket:**

Dependency to openy_gc_auth_custom is not needed for Demo content. It usually blocks or makes it tricky to run demo content migration without a prepared custom authentication method (you have to setup private storage first).
In most cases, we have to import demo content right after Virtual Y installation.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [x] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
