### PR TITLE
[VYMCA-116] Provide search functionality

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,12 @@
         "patches": {
             "drupal/recurring_events": {
                 "Publishing Series Workflow Should Be Reflected in Instances [3178669]": "https://www.drupal.org/files/issues/2020-10-28/recurring_events-status_changes-3178669-5.patch"
+            },
+            "drupal/search_api": {
+                "Add a \"Role-based access\" processor [2898334]": "https://www.drupal.org/files/issues/2021-01-31/2898334-30--role_based_access_check.patch"
+            },
+            "ymcatwincities/openy": {
+                "[PRODDEV-240] Display search input field for the lily theme": "https://patch-diff.githubusercontent.com/raw/ymcatwincities/openy/pull/2420.patch"
             }
         }
     }

--- a/modules/openy_gc_search/README.md
+++ b/modules/openy_gc_search/README.md
@@ -1,0 +1,19 @@
+# Open Y Virtual YMCA Search
+
+The search functionality is based on the Drupal Search API and the search configuration for Open Y
+(see `openy_search_api` module).
+
+The module provides modifications for the search index to include the Virtual Y entities to the content,
+indexed for the search, and also altering the search view title output to wrap the entity title with a
+link to the correspondent Virtual Y page.
+
+For the case your site has custom search you'll need to make sure you've included Virtual Y entity types
+and bundles to the datasources configs, as well as configured view modes for them in the specific index
+fields (like `rendered_output`), and also made needed changes in the enabled processors' configs.
+You can use the `openy_gc_search.install` as an example of such changes.
+
+Other part of the module, an implementation of the `hook_preprocess_views_view_field` makes title
+altering -- to provide the right link for the Virtual Y entities. For the case of custom search
+configuration on your project you'll need to implement this hook on your custom module, or create
+a patch for the current one -- to alter the output in a right way on the search view and its field
+you need.

--- a/modules/openy_gc_search/openy_gc_search.info.yml
+++ b/modules/openy_gc_search/openy_gc_search.info.yml
@@ -1,0 +1,10 @@
+name: Open Y Virtual YMCA Search
+type: module
+description: 'Provides Open Y Virtual YMCA Search functionality.'
+package: Open Y Virtual YMCA
+version: 0.1
+core: 8.x
+core_version_requirement: ^8 || ^9
+dependencies:
+  - drupal:openy_gated_content
+  - drupal:openy_search_api

--- a/modules/openy_gc_search/openy_gc_search.install
+++ b/modules/openy_gc_search/openy_gc_search.install
@@ -1,0 +1,63 @@
+<?php
+
+/**
+ * @file
+ * Installation file for Open Y Virtual YMCA Search.
+ */
+
+/**
+ * Implements hook_install().
+ */
+function openy_gc_search_install() {
+  /** @var \Drupal\search_api\Entity\Index $search_api_index */
+  $search_api_index = \Drupal::entityTypeManager()->getStorage('search_api_index')
+    ->load('search_content');
+
+  // Modify the Content datasource configuration.
+  $ds_config = $search_api_index->getDatasource('entity:node')->getConfiguration();
+  $node_gc_bundles = ['gc_video', 'vy_blog_post'];
+  if (!$ds_config['bundles']['default']) {
+    $ds_config['bundles']['selected'] = array_unique(array_merge($ds_config['bundles']['selected'], $node_gc_bundles));
+  }
+  else {
+    $ds_config['bundles']['selected'] = array_diff($ds_config['bundles']['selected'], $node_gc_bundles);
+  }
+  $search_api_index->getDatasource('entity:node')->setConfiguration($ds_config);
+
+  // Add the Event instance entity datasource.
+  $datasource = \Drupal::getContainer()
+    ->get('search_api.plugin_helper')
+    ->createDatasourcePlugin($search_api_index, 'entity:eventinstance', [
+      'bundles' => [
+        'default' => FALSE,
+        'selected' => ['live_stream', 'virtual_meeting'],
+      ],
+    ]);
+  $search_api_index->addDatasource($datasource);
+
+  // Modify rendered_entity field configuration.
+  $f_config = $search_api_index->getField('rendered_item')->getConfiguration();
+  $f_config['view_mode']['entity:node']['gc_video'] = 'default';
+  $f_config['view_mode']['entity:node']['vy_blog_post'] = 'default';
+  $f_config['view_mode']['entity:eventinstance'] = [
+    'live_stream' => 'default',
+    'virtual_meeting' => 'default',
+  ];
+  $search_api_index->getField('rendered_item')->setConfiguration($f_config);
+
+  // Modify type_boost processor configuration.
+  $p_config = $search_api_index->getProcessor('type_boost')->getConfiguration();
+  $default_boost = $p_config['boosts']['entity:node']['datasource_boost'];
+  $p_config['boosts']['entity:node']['bundle_boosts']['gc_video'] = $default_boost;
+  $p_config['boosts']['entity:node']['bundle_boosts']['vy_blog_post'] = $default_boost;
+  $p_config['boosts']['entity:eventinstance'] = [
+    'datasource_boost' => $default_boost,
+    'bundle_boosts' => [
+      'live_stream' => $default_boost,
+      'virtual_meeting' => $default_boost,
+    ],
+  ];
+  $search_api_index->getProcessor('type_boost')->setConfiguration($p_config);
+
+  $search_api_index->save();
+}

--- a/modules/openy_gc_search/openy_gc_search.install
+++ b/modules/openy_gc_search/openy_gc_search.install
@@ -59,5 +59,15 @@ function openy_gc_search_install() {
   ];
   $search_api_index->getProcessor('type_boost')->setConfiguration($p_config);
 
+  $search_api_index->addProcessor(\Drupal::getContainer()
+    ->get('search_api.plugin_helper')
+    ->createProcessorPlugin($search_api_index, 'content_access'));
+
+  $search_api_index->addProcessor(\Drupal::getContainer()
+    ->get('search_api.plugin_helper')
+    ->createProcessorPlugin($search_api_index, 'role_access'));
+
   $search_api_index->save();
+
+  $search_api_index->clear();
 }

--- a/modules/openy_gc_search/openy_gc_search.module
+++ b/modules/openy_gc_search/openy_gc_search.module
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * @file
+ * The openy_gc_search module routines.
+ */
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Render\Markup;
+
+/**
+ * Implements hook_preprocess_HOOK() for views_view_field template.
+ */
+function openy_gc_search_preprocess_views_view_field(&$variables) {
+  if ($variables['view']->id() !== 'search_content'
+    || $variables['field']->field !== 'title'
+    || empty($variables['row']->_object)) {
+    return;
+  }
+
+  $entity = $variables['row']->_object->getEntity();
+
+  if (empty($entity) || !($entity instanceof EntityInterface)) {
+    return;
+  }
+
+  $app_routes = [
+    'node' => [
+      'gc_video' => '/video/',
+      'vy_blog_post' => '/blog-post/',
+    ],
+    'eventinstance' => [
+      'live_stream' => '/live-stream/',
+      'virtual_meeting' => '/virtual-meeting/',
+    ],
+  ];
+
+  $entity_type_id = $entity->getEntityTypeId();
+  $entity_bundle = $entity->bundle();
+  if (!array_key_exists($entity_type_id, $app_routes)
+    || !array_key_exists($entity_bundle, $app_routes[$entity_type_id])) {
+    return;
+  }
+  $app_route = $app_routes[$entity_type_id][$entity_bundle];
+
+  $virtual_y_url = \Drupal::configFactory()->get('openy_gated_content.settings')->get('virtual_y_url');
+  if (empty($virtual_y_url)) {
+    return;
+  }
+
+  $title = $entity_type_id === 'node' ? $entity->label() :
+    ($entity->get('field_ls_title')->value ?: $entity->get('title')->value);
+  $link = '<a href="' . $virtual_y_url . '#' . $app_route . $entity->uuid() . '">' . $title . '</a>';
+  $variables['output'] = Markup::create($link);
+}


### PR DESCRIPTION
https://fivejars.atlassian.net/browse/VYMCA-116

## Steps to test:

- [ ] Log in as an admin
- [ ] (openy_carnation) Enable the search icon display in the theme settings (/admin/appearance/settings/openy_carnation)
![image](https://user-images.githubusercontent.com/5138333/103664581-1c577f00-4f7b-11eb-8c22-75c19433cf55.png)

- [ ] Enable the `Open Y Virtual YMCA Search` module and all the modules it depends on.
![image](https://user-images.githubusercontent.com/5138333/103664881-6b9daf80-4f7b-11eb-8216-14e06b0bedfe.png)

- [ ] Go to the Search API settings page, `Search content` index, and run the indexation using `Index now` button
![image](https://user-images.githubusercontent.com/5138333/103665765-7ad12d00-4f7c-11eb-9cd3-7e0dadadf156.png)

- [ ] Ensure the content was indexed successfully
![image](https://user-images.githubusercontent.com/5138333/103665918-a7854480-4f7c-11eb-9877-e91566c79c78.png)

- [ ] Ensure you're logged in as a user with `administrator` or one of the Virtual Y roles.
- [ ] Return to the site homepage and try to search for some content:
![image](https://user-images.githubusercontent.com/5138333/103666216-0054dd00-4f7d-11eb-9bb9-9372e2fc3898.png)

- [ ] Ensure the link leads you to the content in a Virtual Y if the page found is related to an app content -- or to the page directly for other content

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
