### PR TITLE
Association number field validation applied

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_yusa/src/Plugin/GCIdentityProvider/YUSA.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_yusa/src/Plugin/GCIdentityProvider/YUSA.php
@@ -110,7 +110,7 @@ class YUSA extends GCIdentityProviderPluginBase {
       '#default_value' => $config['association_number'],
       '#attributes' => [
         'inputmode' => 'numeric',
-        'pattern' => '[0-9]*',
+        'pattern' => '[0-9]{4}',
       ],
       '#maxlength' => 4,
       '#required' => TRUE,

--- a/modules/openy_gc_auth/modules/openy_gc_auth_yusa/src/Plugin/GCIdentityProvider/YUSA.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_yusa/src/Plugin/GCIdentityProvider/YUSA.php
@@ -105,12 +105,14 @@ class YUSA extends GCIdentityProviderPluginBase {
 
     $form['association_number'] = [
       '#title' => $this->t('Association number'),
-      '#type' => 'number',
-      '#min' => 0,
-      '#max' => 9999,
-      '#size' => 4,
+      '#type' => 'textfield',
       '#description' => $this->t('This is usually 4 digits.'),
       '#default_value' => $config['association_number'],
+      '#attributes' => [
+        'inputmode' => 'numeric',
+        'pattern' => '[0-9]*',
+      ],
+      '#maxlength' => 4,
       '#required' => TRUE,
     ];
 

--- a/modules/openy_gc_auth/modules/openy_gc_auth_yusa/src/Plugin/GCIdentityProvider/YUSA.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_yusa/src/Plugin/GCIdentityProvider/YUSA.php
@@ -105,7 +105,10 @@ class YUSA extends GCIdentityProviderPluginBase {
 
     $form['association_number'] = [
       '#title' => $this->t('Association number'),
-      '#type' => 'textfield',
+      '#type' => 'number',
+      '#min' => 0,
+      '#max' => 9999,
+      '#size' => 4,
       '#description' => $this->t('This is usually 4 digits.'),
       '#default_value' => $config['association_number'],
       '#required' => TRUE,


### PR DESCRIPTION
**Related Issue/Ticket:**

(Replace this line with a link to the related GitHub issue on [ymcatwincities/openy_gated_content](https://github.com/ymcatwincities/openy_gated_content/issues) or your own ticketing system)

## Steps to test:

- [ ] Enable the Open Y Virtual YMCA Auth Y-USA module
- [ ] Go to the configuration page at Virtual Y > GC Auth > YUSA
- [ ] The YUSA settings are at /admin/openy/virtual-ymca/gc-auth-settings/provider/yusa
- [ ] Y-USA provider configuration form will show, check and verify 'Association field' with with put some character, it should not more than 4 characters.
- [ ] Finally observe the issue is resolved.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:
 - [ ]  Go to the configuration page, the YUSA settings are at /admin/openy/virtual-ymca/gc-auth-settings/provider/yusa
 - [ ]  Y-USA provider configuration form will show, check and verify 'Association field' with with put some character, it should not more than 4 characters.
 - [ ] 
- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
