### PR TITLE
Use range instead of limit for autologout cron

### DIFF
--- a/modules/openy_gc_autologout/openy_gc_autologout.module
+++ b/modules/openy_gc_autologout/openy_gc_autologout.module
@@ -45,7 +45,7 @@ function openy_gc_autologout_cron() {
 function openy_gc_autologout_users() {
   $results = \Drupal::database()->select('sessions', 's')
     ->fields('s', ['uid', 'sid ', 'timestamp'])
-    ->limit(50)
+    ->range(0, 50)
     ->execute()
     ->fetchAll();
 


### PR DESCRIPTION
**Related Issue/Ticket:**

Resolves https://github.com/ymcatwincities/openy_gated_content/issues/95

## Steps to test:

- [ ] Visit https://sandbox-carnation-std-virtual-y.openy.org
- [ ] Log in as admin, enable Autologout and Dblog modules
- [ ] Run cron
- [ ] Observe no errors

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [x] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
