### PR TITLE
[PRODDEV-188] Fix Activity Log export if user is null

### DIFF
--- a/modules/openy_gc_log/src/LogArchiver.php
+++ b/modules/openy_gc_log/src/LogArchiver.php
@@ -267,7 +267,7 @@ class LogArchiver {
       $entity_id = $log->get('entity_id')->value;
       $export_row = [
         'created' => date('m/d/Y - H:i:s', $log->get('created')->value),
-        'user' => $log->get('uid')->target_id ? $log->get('uid')->entity->getEmail() : '',
+        'user' => ($log->get('uid')->target_id && !is_null($log->get('uid')->entity)) ? $log->get('uid')->entity->getEmail() : '',
         'event_type' => $event_type,
         'entity_type' => $entity_type,
         'entity_bundle' => $entity_bundle,


### PR DESCRIPTION
**Related Issue/Ticket:**

https://github.com/ymcatwincities/openy_gated_content/issues/102

https://openy.atlassian.net/browse/PRODDEV-188

## Steps to test:

- [ ] Use sandbox site https://sandbox-carnation-std-virtual-y.openy.org/
- [ ] Turn on log module
- [ ] Log into the site
- [ ] View member content 
- [ ] Log out
- [ ] Log back into site https://sandbox-carnation-std-virtual-y.openy.org/ as Admin
- [ ] Delete the member created above
- [ ] Export an activity log

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [X] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [X ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
