### PR TITLE
Fix typo in Daxko barcode config name

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_daxko_barcode/src/Controller/DaxkoBarcodeController.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_daxko_barcode/src/Controller/DaxkoBarcodeController.php
@@ -109,7 +109,7 @@ class DaxkoBarcodeController extends ControllerBase {
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
   public function validate(Request $request, $barcode) {
-    $config = $this->configFactory->get('openy_gc_auth.provider.daxco_barcode');
+    $config = $this->configFactory->get('openy_gc_auth.provider.daxko_barcode');
 
     // First make sure we have barcode in $request.
     if (empty($barcode)) {

--- a/modules/openy_gc_auth/modules/openy_gc_auth_daxko_barcode/src/Form/VirtualYDaxkoBarcodeLoginForm.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_daxko_barcode/src/Form/VirtualYDaxkoBarcodeLoginForm.php
@@ -63,7 +63,7 @@ class VirtualYDaxkoBarcodeLoginForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    $config = $this->configFactory->get('openy_gc_auth.provider.daxco_barcode');
+    $config = $this->configFactory->get('openy_gc_auth.provider.daxko_barcode');
 
     $form['barcode'] = [
       '#title' => $config->get('form_label'),

--- a/modules/openy_gc_auth/modules/openy_gc_auth_daxko_barcode/src/Plugin/GCIdentityProvider/DaxkoBarcode.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_daxko_barcode/src/Plugin/GCIdentityProvider/DaxkoBarcode.php
@@ -11,7 +11,7 @@ use Drupal\openy_gc_auth\GCIdentityProviderPluginBase;
  * @GCIdentityProvider(
  *   id="daxkobarcode",
  *   label = @Translation("Daxko barcode provider"),
- *   config="openy_gc_auth.provider.daxco_barcode"
+ *   config="openy_gc_auth.provider.daxko_barcode"
  * )
  */
 class DaxkoBarcode extends GCIdentityProviderPluginBase {


### PR DESCRIPTION
**Related Issue/Ticket:**

The PR fixes the typo in the Daxko barcode config name. Different config names are used in the module:

- `openy_gc_auth.provider.daxko_barcode` used [here](https://github.com/fivejars/openy_gated_content/blob/master/modules/openy_gc_auth/modules/openy_gc_auth_daxko_barcode/config/install/openy_gc_auth.provider.daxko_barcode.yml)
- `openy_gc_auth.provider.daxco_barcode` used [here](https://github.com/fivejars/openy_gated_content/blob/master/modules/openy_gc_auth/modules/openy_gc_auth_daxko_barcode/src/Plugin/GCIdentityProvider/DaxkoBarcode.php#L14) and [here](https://github.com/fivejars/openy_gated_content/blob/master/modules/openy_gc_auth/modules/openy_gc_auth_daxko_barcode/src/Controller/DaxkoBarcodeController.php#L112) 

## Steps to test:

- [ ] First do this
- [ ] Then do this (and look at this great screenshot).
- [ ] Finally observe the issue is resolved.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
