### PR TITLE
[PRODDEV-179] Store references entities' info in the metadata field, …

### DIFF
--- a/modules/openy_gc_log/config/install/views.view.virtual_y_logs.yml
+++ b/modules/openy_gc_log/config/install/views.view.virtual_y_logs.yml
@@ -200,6 +200,71 @@ display:
           entity_type: log_entity
           entity_field: created
           plugin_id: field
+        email:
+          id: email
+          table: log_entity
+          field: email
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: log_entity
+          entity_field: email
+          plugin_id: field
         name:
           id: name
           table: users_field_data
@@ -244,10 +309,10 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: ''
+          empty: '{{ email }}'
           hide_empty: false
           empty_zero: false
-          hide_alter_empty: true
+          hide_alter_empty: false
           click_sort_column: value
           type: user_name
           settings:
@@ -330,6 +395,136 @@ display:
           entity_type: log_entity
           entity_field: event_type
           plugin_id: field
+        entity_type:
+          id: entity_type
+          table: log_entity
+          field: entity_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Entity Type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: log_entity
+          entity_field: entity_type
+          plugin_id: field
+        entity_bundle:
+          id: entity_bundle
+          table: log_entity
+          field: entity_bundle
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Bundle
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: log_entity
+          entity_field: entity_bundle
+          plugin_id: field
         entity_id:
           id: entity_id
           table: log_entity
@@ -395,71 +590,6 @@ display:
           entity_type: log_entity
           entity_field: entity_id
           plugin_id: field
-        entity_type:
-          id: entity_type
-          table: log_entity
-          field: entity_type
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: 'Entity Type'
-          exclude: true
-          alter:
-            alter_text: false
-            text: ''
-            make_link: true
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          settings:
-            link_to_entity: false
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-          entity_type: log_entity
-          entity_field: entity_type
-          plugin_id: field
         payload:
           id: payload
           table: log_entity
@@ -470,8 +600,8 @@ display:
           label: 'Event Info'
           exclude: false
           alter:
-            alter_text: true
-            text: "{% if entity_id != false %}\r\n<a href=\"/{{ entity_type == 'node' ? 'node' : 'events' }}/{{ entity_id }}\">{{ payload }}</a>\r\n{% else %}\r\n{{ payload }}\r\n{% endif %}\r\n"
+            alter_text: false
+            text: ''
             make_link: false
             path: ''
             absolute: false
@@ -1044,6 +1174,71 @@ display:
           entity_type: log_entity
           entity_field: changed
           plugin_id: field
+        email:
+          id: email
+          table: log_entity
+          field: email
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: true
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: log_entity
+          entity_field: email
+          plugin_id: field
         name:
           id: name
           table: users_field_data
@@ -1088,10 +1283,10 @@ display:
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
-          empty: ''
+          empty: '{{ email }}'
           hide_empty: false
           empty_zero: false
-          hide_alter_empty: true
+          hide_alter_empty: false
           click_sort_column: value
           type: user_name
           settings:

--- a/modules/openy_gc_log/config/install/views.view.virtual_y_logs.yml
+++ b/modules/openy_gc_log/config/install/views.view.virtual_y_logs.yml
@@ -1068,7 +1068,7 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: 'Below are this month''s logs. Older log entries can be found in the <a href=/admin/content/files?filename=virtual-y&filemime=application/x-gzip>Log Archives</a>.'
+          content: '<div class="messages messages--warning">Below are this month's logs. Older log entries can be found in the <a href=/admin/content/files?filename=virtual-y&filemime=application/x-gzip>Log Archives</a>.</div>'
           plugin_id: text_custom
       footer: {  }
       empty: {  }

--- a/modules/openy_gc_log/config/install/views.view.virtual_y_logs.yml
+++ b/modules/openy_gc_log/config/install/views.view.virtual_y_logs.yml
@@ -1058,7 +1058,18 @@ display:
           entity_field: created
           plugin_id: date
       title: 'Virtual Y Logs'
-      header: {  }
+      header:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          empty: true
+          tokenize: false
+          content: 'Below are this month''s logs. Older log entries can be found in the <a href=/admin/content/files?filename=virtual-y&filemime=application/x-gzip>Log Archives</a>.'
+          plugin_id: text_custom
       footer: {  }
       empty: {  }
       relationships:

--- a/modules/openy_gc_log/config/install/views.view.virtual_y_logs.yml
+++ b/modules/openy_gc_log/config/install/views.view.virtual_y_logs.yml
@@ -1068,7 +1068,7 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: '<div class="messages messages--warning">Below are this month's logs. Older log entries can be found in the <a href=/admin/content/files?filename=virtual-y&filemime=application/x-gzip>Log Archives</a>.</div>'
+          content: '<div class="messages messages--warning">Below are this month\'s logs. Older log entries can be found in the <a href=/admin/content/files?filename=virtual-y&filemime=application/x-gzip>Log Archives</a>.</div>'
           plugin_id: text_custom
       footer: {  }
       empty: {  }

--- a/modules/openy_gc_log/config/install/views.view.virtual_y_logs.yml
+++ b/modules/openy_gc_log/config/install/views.view.virtual_y_logs.yml
@@ -1068,7 +1068,7 @@ display:
           admin_label: ''
           empty: true
           tokenize: false
-          content: '<div class="messages messages--warning">Below are this month\'s logs. Older log entries can be found in the <a href=/admin/content/files?filename=virtual-y&filemime=application/x-gzip>Log Archives</a>.</div>'
+          content: '<div class="messages messages--warning">Below are this months logs. Older log entries can be found in the <a href=/admin/content/files?filename=virtual-y&filemime=application/x-gzip>Log Archives</a>.</div>'
           plugin_id: text_custom
       footer: {  }
       empty: {  }

--- a/modules/openy_gc_log/openy_gc_log.install
+++ b/modules/openy_gc_log/openy_gc_log.install
@@ -131,3 +131,28 @@ function openy_gc_log_update_8006() {
     $fields[$field_name]
   );
 }
+
+/**
+ * Import view config and update entity.
+ */
+function openy_gc_log_update_8007() {
+  $config_dir = drupal_get_path('module', 'openy_gc_log');
+  $config_dir .= '/config/install/';
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'views.view.virtual_y_logs',
+  ]);
+
+  // Update entity to add the changed field.
+  $entity_type = 'log_entity';
+  $field_name = 'event_metadata';
+  $fields = [];
+  LogEntity::defineMetadataField($fields);
+  \Drupal::entityDefinitionUpdateManager()->installFieldStorageDefinition(
+    $field_name,
+    $entity_type,
+    $entity_type,
+    $fields[$field_name]
+  );
+}

--- a/modules/openy_gc_log/openy_gc_log.install
+++ b/modules/openy_gc_log/openy_gc_log.install
@@ -133,18 +133,9 @@ function openy_gc_log_update_8006() {
 }
 
 /**
- * Import view config and update entity.
+ * Update Log entity to add the event_metadata field.
  */
 function openy_gc_log_update_8007() {
-  $config_dir = drupal_get_path('module', 'openy_gc_log');
-  $config_dir .= '/config/install/';
-  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
-  $config_importer->setDirectory($config_dir);
-  $config_importer->importConfigs([
-    'views.view.virtual_y_logs',
-  ]);
-
-  // Update entity to add the changed field.
   $entity_type = 'log_entity';
   $field_name = 'event_metadata';
   $fields = [];
@@ -155,4 +146,17 @@ function openy_gc_log_update_8007() {
     $entity_type,
     $fields[$field_name]
   );
+}
+
+/**
+ * Import logs view config.
+ */
+function openy_gc_log_update_8008() {
+  $config_dir = drupal_get_path('module', 'openy_gc_log');
+  $config_dir .= '/config/install/';
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'views.view.virtual_y_logs',
+  ]);
 }

--- a/modules/openy_gc_log/openy_gc_log.post_update.php
+++ b/modules/openy_gc_log/openy_gc_log.post_update.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * @file
+ * Contains hook_post_update_NAME() implementations.
+ */
+
+use Drupal\openy_gc_log\Entity\LogEntityInterface;
+
+/**
+ * Update all existing Virtual Y Log entities with values for metadata field.
+ */
+function openy_gc_log_post_update_update_metadata(&$sandbox) {
+  $storage = Drupal::entityTypeManager()->getStorage('log_entity');
+  if (!isset($sandbox['max'])) {
+    $query = $storage->getQuery()
+      ->condition('event_type', [
+        LogEntityInterface::EVENT_TYPE_ENTITY_VIEW,
+        LogEntityInterface::EVENT_TYPE_VIDEO_PLAYBACK_STARTED,
+        LogEntityInterface::EVENT_TYPE_VIDEO_PLAYBACK_ENDED,
+      ], 'IN')
+      ->notExists('event_metadata');
+    $sandbox['ids'] = $query->execute();
+    $sandbox['max'] = $query->count()->execute();
+  }
+  $ids = array_slice($sandbox['ids'], 0, 50);
+  $logs = $storage->loadMultiple($ids);
+  foreach ($logs as $log) {
+    if (!$log instanceof LogEntityInterface) {
+      continue;
+    }
+    $vy_logger = \Drupal::getContainer()->get('openy_gc_log.logger');
+    $log->set('event_metadata', serialize($vy_logger->getMetadata($log)));
+    $log->save();
+  }
+  $sandbox['ids'] = array_diff($sandbox['ids'], $ids);
+  $sandbox['#finished'] = (count($sandbox['ids']) === 0) ?: count($sandbox['ids']) / $sandbox['max'];
+  if ($sandbox['#finished']) {
+    return t('Metadata was saved for @count log records', ['@count' => $sandbox['max']]);
+  }
+}

--- a/modules/openy_gc_log/openy_gc_log.services.yml
+++ b/modules/openy_gc_log/openy_gc_log.services.yml
@@ -5,7 +5,7 @@ services:
 
   openy_gc_log.log_archiver:
     class: Drupal\openy_gc_log\LogArchiver
-    arguments: ['@entity_type.manager', '@logger.channel.openy_gc_log', '@config.factory', '@file_system', '@settings', '@module_handler', '@date.formatter']
+    arguments: ['@entity_type.manager', '@logger.channel.openy_gc_log', '@config.factory', '@file_system', '@settings', '@module_handler', '@date.formatter', '@openy_gc_log.logger']
 
   logger.channel.openy_gc_log:
     parent: logger.channel_base

--- a/modules/openy_gc_log/src/Controller/LogController.php
+++ b/modules/openy_gc_log/src/Controller/LogController.php
@@ -64,6 +64,9 @@ class LogController extends ControllerBase {
   public function index(Request $request) {
     $content = $request->getContent();
     $params = json_decode($content, TRUE);
+    // We should be sure we are logging activity of the current user.
+    $params['uid'] = $this->currentUser()->id();
+    $params['email'] = $this->currentUser()->getEmail();
     $status = $this->gcLogger->addLog($params);
     if ($status instanceof LogEntity) {
       return new AjaxResponse([

--- a/modules/openy_gc_log/src/Entity/LogEntity.php
+++ b/modules/openy_gc_log/src/Entity/LogEntity.php
@@ -279,7 +279,7 @@ class LogEntity extends ContentEntityBase implements LogEntityInterface {
     $fields['event_metadata'] = BaseFieldDefinition::create('string')
       ->setLabel(t('Event Metadata'))
       ->setDescription(t('The event metadata, related to the Log entity.'))
-      ->setSetting('max_length', 255)
+      ->setSetting('max_length', 4096)
       ->setDefaultValue('');
   }
 

--- a/modules/openy_gc_log/src/Entity/LogEntity.php
+++ b/modules/openy_gc_log/src/Entity/LogEntity.php
@@ -62,6 +62,7 @@ class LogEntity extends ContentEntityBase implements LogEntityInterface {
     self::definePayloadField($fields);
     self::defineCreatedField($fields);
     self::defineChangedField($fields);
+    self::defineMetadataField($fields);
     return $fields;
   }
 
@@ -266,6 +267,20 @@ class LogEntity extends ContentEntityBase implements LogEntityInterface {
     $fields['changed'] = BaseFieldDefinition::create('changed')
       ->setLabel(t('Changed'))
       ->setDescription(t('The time that the entity was last edited.'));
+  }
+
+  /**
+   * Define event_metadata field.
+   *
+   * @param array $fields
+   *   Fields.
+   */
+  public static function defineMetadataField(array &$fields) {
+    $fields['event_metadata'] = BaseFieldDefinition::create('string')
+      ->setLabel(t('Event Metadata'))
+      ->setDescription(t('The event metadata, related to the Log entity.'))
+      ->setSetting('max_length', 255)
+      ->setDefaultValue('');
   }
 
   /**

--- a/modules/openy_gc_log/src/LogArchiver.php
+++ b/modules/openy_gc_log/src/LogArchiver.php
@@ -4,7 +4,6 @@ namespace Drupal\openy_gc_log;
 
 use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Datetime\DateFormatterInterface;
-use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\Core\File\FileSystem;
@@ -13,6 +12,7 @@ use Drupal\Core\Site\Settings;
 use Drupal\csv_serialization\Encoder\CsvEncoder;
 use Drupal\file\Entity\File;
 use Drupal\openy_gc_log\Entity\LogEntityInterface;
+use Drupal\user\UserInterface;
 
 /**
  * Log Archiver service.
@@ -101,6 +101,13 @@ class LogArchiver {
   protected $dateFormatter;
 
   /**
+   * The Gated Content Logger.
+   *
+   * @var \Drupal\openy_gc_log\Logger
+   */
+  protected $gcLogger;
+
+  /**
    * LogArchiver constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManager $entityTypeManager
@@ -117,6 +124,8 @@ class LogArchiver {
    *   The module handler.
    * @param \Drupal\Core\Datetime\DateFormatterInterface $date_formatter
    *   The date formatter service.
+   * @param \Drupal\openy_gc_log\Logger $gcLogger
+   *   The Gated Content Logger.
    */
   public function __construct(
     EntityTypeManager $entityTypeManager,
@@ -125,7 +134,8 @@ class LogArchiver {
     FileSystem $fileSystem,
     Settings $settings,
     ModuleHandlerInterface $module_handler,
-    DateFormatterInterface $date_formatter
+    DateFormatterInterface $date_formatter,
+    Logger $gcLogger
   ) {
     $this->entityTypeManager = $entityTypeManager;
     $this->logger = $logger;
@@ -134,6 +144,7 @@ class LogArchiver {
     $this->settings = $settings;
     $this->moduleHandler = $module_handler;
     $this->dateFormatter = $date_formatter;
+    $this->gcLogger = $gcLogger;
   }
 
   /**
@@ -265,6 +276,10 @@ class LogArchiver {
    */
   protected function prepareLogsForExport($logFileName = '') {
     foreach ($this->logEntities as $log) {
+      if (!$log instanceof LogEntityInterface) {
+        continue;
+      }
+
       $fileName = $logFileName ?: $this->makeFilename($log);
       if (!isset($this->preparedLogs[$fileName])) {
         $this->preparedLogs[$fileName] = [
@@ -276,9 +291,12 @@ class LogArchiver {
       $entity_type = $log->get('entity_type')->value;
       $entity_bundle = $log->get('entity_bundle')->value;
       $entity_id = $log->get('entity_id')->value;
+      $user_data = $log->get('uid')->target_id && ($log->get('uid')->entity instanceof UserInterface) ?
+        $log->get('uid')->entity->getEmail() :
+        $log->get('email')->value;
       $export_row = [
         'created' => date('m/d/Y - H:i:s', $log->get('created')->value),
-        'user' => $log->get('uid')->target_id ? $log->get('uid')->entity->getEmail() : '',
+        'user' => $user_data,
         'event_type' => $event_type,
         'entity_type' => $entity_type,
         'entity_bundle' => $entity_bundle,
@@ -293,19 +311,20 @@ class LogArchiver {
         case LogEntityInterface::EVENT_TYPE_ENTITY_VIEW:
         case LogEntityInterface::EVENT_TYPE_VIDEO_PLAYBACK_STARTED:
         case LogEntityInterface::EVENT_TYPE_VIDEO_PLAYBACK_ENDED:
-          $entity_type_id = $entity_type === 'node' ? 'node' : 'eventinstance';
-          $entity = $this->entityTypeManager->getStorage($entity_type_id)
-            ->load($entity_id);
-          if (!$entity instanceof EntityInterface) {
-            continue 2;
+          $metadata = $this->gcLogger->getMetadata($log);
+          if (empty($metadata)) {
+            $metadata = unserialize($log->get('event_metadata')->value, ['allowed_classes' => FALSE]);
           }
-          $export_row['entity_title'] = $entity_type === 'node' ?
-            $entity->label() :
-            ($entity->get('field_ls_title')->value ?: $entity->get('title')->value);
-          $export_row['entity_instructor_name'] = $entity_type === 'node' ?
-            ($entity_bundle === 'gc_video' ? $entity->get('field_gc_video_instructor')->value : '') :
-            ($entity->get('field_ls_host_name')->value ?: $entity->get('host_name')->value);
-          $export_row['entity_created'] = date('m/d/Y - H:i:s', $entity->getCreatedTime());
+          foreach ([
+            'entity_title',
+            'entity_instructor_name',
+            'entity_created',
+          ] as $key) {
+            if (!array_key_exists($key, $metadata)) {
+              continue 1;
+            }
+            $export_row[$key] = $metadata[$key];
+          }
           break;
 
         case LogEntityInterface::EVENT_TYPE_USER_ACTIVITY:


### PR DESCRIPTION
…and use this info if the entity is not there already

https://openy.atlassian.net/browse/PRODDEV-179

## Steps to test:

- [ ] Log in as an admin
- [ ] Enable "Open Y Virtual YMCA Log" module
- [ ] Navigate through the site
- [ ] In the incognito browser mode or another browser log in as a common VY user
- [ ] Navigate through the site again
- [ ] Ensure the logs are displayed on the /admin/virtual-y-logs page
![image](https://user-images.githubusercontent.com/5138333/106913217-6fecf200-670c-11eb-941b-94ea4bf52aa9.png)

- [ ] Export the logs
- [ ] Ensure all the info is there
- [ ] Remove the dummy user you've used to navigate through the VY
- [ ] Ensure the logs are still available -- just the user's email is no more clickable
![image](https://user-images.githubusercontent.com/5138333/106913429-a62a7180-670c-11eb-9621-46981d1caceb.png)

- [ ] Export the logs and ensure the resulting file coincides with the previously exported
- [ ] Remove some of the entities you've looked, when surfed around the VY
- [ ] Ensure the logs are still available and contain the entities titles and instructor name of the removed entity
- [ ] Export the logs and ensure the resulting file coincides with the previously exported

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- [x] This PR  provides updates to support the upgrade path
- [x] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
