### PR TITLE
[VYMCA-115] Admin accounts for CSV import

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/README.md
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/README.md
@@ -94,9 +94,3 @@ See https://www.drupal.org/project/migrate_tools/issues/2809433#comment-13362844
 
 To fix this - apply a patch for migrate_tools
 patches/migrate_tools_sync_option_for_drush8.patch
-
-
-### Migrate tools 5.0 and sync option from UI
-
-For the ability to use sync option from UI in Migrate tools 5.0 we need to apply
-a custom patch, see `composer.json` of this module.

--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/README.md
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/README.md
@@ -94,3 +94,11 @@ See https://www.drupal.org/project/migrate_tools/issues/2809433#comment-13362844
 
 To fix this - apply a patch for migrate_tools
 patches/migrate_tools_sync_option_for_drush8.patch
+
+### Migrate tools 5.0 and sync option from UI
+
+In the current module version no need to apply a patch to add sync option for
+migrate tools. Migrate tools UI form was altered in
+`openy_gc_auth_custom_form_migration_execute_form_alter` and used overridden
+`MigrateBatchExecutable.php`. In this case we have only one requirement -
+`drupal:migrate_tools` version should `be 8.x-5.0`.

--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/config/install/migrate_plus.migration.gc_auth_custom_users.yml
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/config/install/migrate_plus.migration.gc_auth_custom_users.yml
@@ -54,5 +54,8 @@ process:
       method: row
       source: email
       message: 'Field email is missed'
+    -
+      plugin: vy_skip_row_if_email_excluded
+      source: email
 destination:
   plugin: 'entity:user'

--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/config/install/openy_gc_auth.provider.custom.yml
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/config/install/openy_gc_auth.provider.custom.yml
@@ -5,3 +5,4 @@ email_verification_link_life_time: '14400'
 email_verification_text: 'Hello! <br> You’re just one step away from accessing your Virtual YMCA. Please open the link below to begin enjoying YMCA content made exclusively for members like you.'
 verification_message: 'We have sent a verification link to the email address you provided. Please open this link and activate your account. If you do not receive an email, please try again or contact us at XXX-XXX-XXXX to ensure we have the correct email on file for your membership.'
 one_time_link_invalid_message: 'You have tried to use a one-time login link that has either been used or is no longer valid. Please request a new one using the form below.'
+exclude_users: {  }

--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/openy_gc_auth_custom.install
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/openy_gc_auth_custom.install
@@ -147,3 +147,27 @@ function openy_gc_auth_custom_update_8008(&$sandbox) {
     ->set('one_time_link_invalid_message', $message)
     ->save();
 }
+
+/**
+ * Add SkipRowIfEmailExcluded migrate process plugin to csv migration.
+ */
+function openy_gc_auth_custom_update_8009(&$sandbox) {
+  $config_dir = drupal_get_path('module', 'openy_gc_auth_custom') . '/config/';
+  // Update multiple configurations.
+  $configs = [
+    'openy_gc_auth.provider.custom' => [
+      'exclude_users',
+    ],
+    'migrate_plus.migration.gc_auth_custom_users' => [
+      'process.mail',
+    ],
+  ];
+
+  $config_updater = \Drupal::service('openy_upgrade_tool.param_updater');
+  foreach ($configs as $config_name => $params) {
+    $config = $config_dir . $config_name . '.yml';
+    foreach ($params as $param) {
+      $config_updater->update($config, $config_name, $param);
+    }
+  }
+}

--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Plugin/GCIdentityProvider/Custom.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Plugin/GCIdentityProvider/Custom.php
@@ -2,9 +2,15 @@
 
 namespace Drupal\openy_gc_auth_custom\Plugin\GCIdentityProvider;
 
+use Drupal\Component\Utility\EmailValidatorInterface;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Form\FormBuilderInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Link;
+use Drupal\openy_gated_content\GCUserService;
 use Drupal\openy_gc_auth\GCIdentityProviderPluginBase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Custom identity provider plugin.
@@ -20,6 +26,47 @@ class Custom extends GCIdentityProviderPluginBase {
   const DEFAULT_LINK_LIFE_TIME = 14400;
 
   /**
+   * The email validator.
+   *
+   * @var \Drupal\Component\Utility\EmailValidatorInterface
+   */
+  protected $emailValidator;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    ConfigFactoryInterface $config,
+    EntityTypeManagerInterface $entity_type_manager,
+    FormBuilderInterface $form_builder,
+    GCUserService $gc_user_service,
+    EmailValidatorInterface $email_validator
+  ) {
+
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $config, $entity_type_manager, $form_builder, $gc_user_service);
+    $this->emailValidator = $email_validator;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory'),
+      $container->get('entity_type.manager'),
+      $container->get('form_builder'),
+      $container->get('openy_gated_content.user_service'),
+      $container->get('email.validator')
+    );
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function defaultConfiguration():array {
@@ -31,6 +78,7 @@ class Custom extends GCIdentityProviderPluginBase {
       'email_verification_text' => 'Hello! <br> You’re just one step away from accessing your Virtual YMCA. Please open the link below to begin enjoying YMCA content made exclusively for members like you.',
       'verification_message' => 'We have sent a verification link to the email address you provided. Please open this link and activate your account. If you do not receive an email, please try again or contact us at XXX-XXX-XXXX to ensure we have the correct email on file for your membership.',
       'one_time_link_invalid_message' => 'You have tried to use a one-time login link that has either been used or is no longer valid. Please request a new one using the form below.',
+      'exclude_users' => [],
     ];
   }
 
@@ -149,7 +197,38 @@ class Custom extends GCIdentityProviderPluginBase {
       ],
     ];
 
+    $form['migrate_custom'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Migration users exclude'),
+      '#open' => FALSE,
+    ];
+
+    $form['migrate_custom']['exclude_users'] = [
+      '#title' => $this->t('Users exclude'),
+      '#description' => $this->t('Add users emails that should be excluded from migration (One email per line).'),
+      '#type' => 'textarea',
+      '#default_value' => !empty($config['exclude_users']) ? implode(PHP_EOL, $config['exclude_users']) : '',
+    ];
+
     return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+    $emails_str = $form_state->getValue('exclude_users');
+    if ($emails_str) {
+      $emails = array_filter(explode(PHP_EOL, $emails_str));
+      foreach ($emails as $email) {
+        $clean_email = trim(preg_replace('/\s\s+/', '', $email));
+        if (!$this->emailValidator->isValid($clean_email)) {
+          $form_state->setErrorByName('exclude_users', $this->t('Email "@mail" invalid', [
+            '@mail' => $clean_email,
+          ]));
+        }
+      }
+    }
   }
 
   /**
@@ -165,6 +244,19 @@ class Custom extends GCIdentityProviderPluginBase {
       $this->configuration['email_verification_text'] = !empty($form_state->getValue('email_verification_text')) ? $form_state->getValue('email_verification_text')['value'] : '';
       $this->configuration['verification_message'] = !empty($form_state->getValue('verification_message')) ? $form_state->getValue('verification_message')['value'] : '';
       $this->configuration['one_time_link_invalid_message'] = !empty($form_state->getValue('one_time_link_invalid_message')) ? $form_state->getValue('one_time_link_invalid_message') : '';
+
+      $emails_str = $form_state->getValue('exclude_users');
+      if ($emails_str) {
+        $emails = array_filter(explode(PHP_EOL, $emails_str));
+        $emails_data = array_map(function ($email) {
+          return trim(preg_replace('/\s\s+/', '', $email));
+        }, $emails);
+        $this->configuration['exclude_users'] = $emails_data;
+      }
+      else {
+        $this->configuration['exclude_users'] = [];
+      }
+
       parent::submitConfigurationForm($form, $form_state);
     }
   }

--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Plugin/migrate/process/SkipRowIfEmailExcluded.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Plugin/migrate/process/SkipRowIfEmailExcluded.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\openy_gc_auth_custom\Plugin\migrate\process;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\migrate\ProcessPluginBase;
+use Drupal\migrate\MigrateExecutableInterface;
+use Drupal\migrate\Row;
+use Drupal\migrate\MigrateSkipRowException;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Skips processing the current row when a source value is not set.
+ *
+ * The skip_row_if_email_excluded process plugin checks a value not
+ * exists in excluded list. Otherwise, a MigrateSkipRowException is thrown.
+ *
+ * Example:
+ *
+ * @code
+ *  process:
+ *    mail:
+ *      plugin: vy_skip_row_if_email_excluded
+ *      source: email
+ * @endcode
+ *
+ * @see \Drupal\migrate\Plugin\MigrateProcessInterface
+ *
+ * @MigrateProcessPlugin(
+ *   id = "vy_skip_row_if_email_excluded",
+ *   handle_multiples = TRUE
+ * )
+ */
+class SkipRowIfEmailExcluded extends ProcessPluginBase implements ContainerFactoryPluginInterface {
+
+  use StringTranslationTrait;
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs a EmailAction object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The config factory.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config_factory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->configFactory = $config_factory;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static($configuration, $plugin_id, $plugin_definition,
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function transform($value, MigrateExecutableInterface $migrate_executable, Row $row, $destination_property) {
+    $excluded_users = $this->configFactory
+      ->get('openy_gc_auth.provider.custom')
+      ->get('exclude_users');
+
+    if (in_array($value, $excluded_users)) {
+      throw new MigrateSkipRowException('User with email ' . $value . ' in exclude_users list.');
+    }
+
+    return $value;
+  }
+
+}


### PR DESCRIPTION
**Related Issue/Ticket:**

- https://fivejars.atlassian.net/browse/VYMCA-115
- https://openy.atlassian.net/browse/PRODDEV-178

Some Y's are having issues with giving admin access to the staff members that exist in the CSV file.

**Steps to reproduce:**
    - Run import
    - Edit any imported user and assign a "virtual editor" role
    - Run import one more time
    - Check that user without a "virtual editor" role

**Solution:**

Add settings with the user's emails list that should be skipped during migration.

## Steps to test:

- [ ] Login as admin
- [ ] Go to `/admin/modules`
- [ ] Enable "Open Y Virtual YMCA Auth Custom" module
- [ ] Go to `/admin/openy/virtual-ymca/gc-auth-settings`
- [ ] Set "Custom provider" as default provider
- [ ] Go to `/admin/openy/virtual-ymca/gc-auth-settings/provider/custom`
- [ ] Check that you can see the new section Migration users exclude
- [ ] Add any random email - valid and invalid
- [ ] Check that validation works fine
- [ ] Create `test.csv` file with content:
    
```csv
Member ID,Member First Name,Primary Member,Member Email,Package Name,Package Site
309302,Test,Yes,TEST@GMAIL.COM,OLY - Family - Staff,Oscar Lasko Branch
309303,Jon,No,JON@GMAIL.COM,OLY - Family - Staff,Oscar Lasko Branch
117892,Doe,Yes,Doe@GMAIL.COM,West Chester - SilverSneakers - S & PP,West Chester
91896,Mike,No,SUPERMIKE@GMAIL.COM,Kennett - Family - Full,Kennett Branch
```

- [ ] Go to `/admin/openy/openy-gc-auth/settings/provider/custom/upload-csv`
- [ ] Upload this CSV file and save
- [ ] Go to `/admin/structure/migrate/manage/gc_auth/migrations/gc_auth_custom_users/execute`
- [ ] Set Update checkbox
- [ ] Run import
- [ ] You should see "Processed 4 items (4 created, 0 updated, 0 failed, 0 ignored) - done with 'gc_auth_custom_users' " message
- [ ] Go to `/admin/people`
- [ ] Check that users from CSV file created
- [ ] Remove "Mike 91896" user with SUPERMIKE@GMAIL.COM email (Cancel account -> Delete the account and its content.)
- [ ] Go to `/admin/openy/virtual-ymca/gc-auth-settings/provider/custom`
- [ ] Add SUPERMIKE@GMAIL.COM email to "Migration users exclude" and save
- [ ] Go to `/admin/structure/migrate/manage/gc_auth/migrations/gc_auth_custom_users/execute`
- [ ] Set Update checkbox
- [ ] Run import
- [ ] You should see "Processed 4 items (0 created, 3 updated, 0 failed, 1 ignored) - done with 'gc_auth_custom_users' " message
- [ ] Go to `/admin/people`
- [ ] Check that "Mike 91896" account not restored