### PR TITLE
[YDVY-74] Improve GC authorization.

### DIFF
--- a/modules/openy_gc_auth/openy_gc_auth.services.yml
+++ b/modules/openy_gc_auth/openy_gc_auth.services.yml
@@ -14,4 +14,4 @@ services:
 
   openy_gc_auth.user_authorizer:
     class: Drupal\openy_gc_auth\GCUserAuthorizer
-    arguments: ['@entity_type.manager', '@event_dispatcher', '@logger.factory']
+    arguments: ['@entity_type.manager', '@event_dispatcher', '@logger.factory', '@messenger']

--- a/modules/openy_gc_auth/openy_gc_auth.services.yml
+++ b/modules/openy_gc_auth/openy_gc_auth.services.yml
@@ -14,4 +14,4 @@ services:
 
   openy_gc_auth.user_authorizer:
     class: Drupal\openy_gc_auth\GCUserAuthorizer
-    arguments: ['@entity_type.manager', '@event_dispatcher']
+    arguments: ['@entity_type.manager', '@event_dispatcher', '@logger.factory']

--- a/modules/openy_gc_auth/src/GCUserAuthorizer.php
+++ b/modules/openy_gc_auth/src/GCUserAuthorizer.php
@@ -3,7 +3,9 @@
 namespace Drupal\openy_gc_auth;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Logger\LoggerChannelFactoryInterface;
 use Drupal\openy_gc_auth\Event\GCUserLoginEvent;
+use Drupal\user\UserInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
@@ -28,57 +30,115 @@ class GCUserAuthorizer {
   protected $eventDispatcher;
 
   /**
+   * Logger service.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger;
+
+  /**
    * GCUserAuthorizer constructor.
    *
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   Entity Type Manager.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
    *   Event dispatcher.
+   * @param \Drupal\Core\Logger\LoggerChannelFactoryInterface $logger_channel_factory
+   *   Logger factory.
    */
-  public function __construct(EntityTypeManagerInterface $entityTypeManager, EventDispatcherInterface $event_dispatcher) {
+  public function __construct(EntityTypeManagerInterface $entityTypeManager, EventDispatcherInterface $event_dispatcher, LoggerChannelFactoryInterface $logger_channel_factory) {
     $this->userStorage = $entityTypeManager->getStorage('user');
     $this->eventDispatcher = $event_dispatcher;
+    $this->logger = $logger_channel_factory->get('gc_user_authorizer');
   }
 
   /**
    * {@inheritdoc}
    */
-  public function authorizeUser($name, $email, array $extra_data = []) {
+  public function authorizeUser($name, $mail, array $extra_data = []) {
 
     if (empty($name) || empty($email)) {
       return;
     }
 
-    // Create drupal user if it doesn't exist and login it.
-    $account = user_load_by_mail($email);
-    if (!$account) {
-      $user = $this->userStorage->create();
-      $user->setPassword(user_password());
-      $user->enforceIsNew();
-      $user->setEmail($email);
-      $user->setUsername($name);
-      $user->addRole(self::VIRTUAL_Y_DEFAULT_ROLE);
-      $user->activate();
-      $result = $account = $user->save();
-      if ($result) {
-        $account = user_load_by_mail($email);
+    $account = NULL;
+    // Load drupal user by name and email from SalesForce.
+    $account_by_mail = user_load_by_mail($mail);
+    $account_by_name = user_load_by_name($name);
+
+    // If we can load at least one account by userdata(from Salesforce).
+    if ($account_by_mail || $account_by_name) {
+
+      // If we have two account loaded, we should check if it's one user or two
+      // different(f.e. case if user change email in service provider, but it's
+      // already used in Drupal).
+      if ($account_by_mail && $account_by_name) {
+        // If for email and name from service provider registered two different
+        // account. Should be resolved manually in Drupal.
+        if ($account_by_mail->id() !== $account_by_name->id()) {
+          throw new \Exception("For email '{$mail}' and name '{$name}' registered two different accounts in Virtual Y. Please contact to Virtual Y administrator.");
+        }
+        // If both account point to same User.
+        else {
+          // Doesn't matter, what object to use, as they are the same.
+          $account = $account_by_mail;
+        }
+      }
+      // Loaded one account -> email or name was changed in Service provider.
+      else {
+        // Get existing(loaded) account, that will be logged in.
+        $account = $account_by_mail ? $account_by_mail : $account_by_name;
+        // Get changed in Service provider field, update and log changing of
+        // related field in Drupal.
+        // If $account_by_mail exist, this mean that by name we didn't load user
+        // and name was changed in Service provider.
+        $changed_field = $account_by_mail ? 'name' : 'mail';
+        $old_changed_field_value = $account->get($changed_field)->value;
+        // Set new value (from service provider).
+        $account->set($changed_field, $$changed_field);
+        $account->save();
+
+        $this->logger->error('Service provider user credentials was changed. For User with id:%id changed field \'%field\' from \'%old\' to \'%new\' value',
+          [
+            '%id' => $account->id(),
+            '%field' => $changed_field,
+            '%old' => $old_changed_field_value,
+            '%new' => $$changed_field,
+          ]
+        );
       }
     }
     else {
-      // Activate user if it's not.
-      if (!$account->isActive()) {
-        $account->activate();
-        $account->setPassword(user_password());
-        $account->save();
-      }
+      $account = $this->createUser($name, $mail, TRUE);
     }
+
+    if ($account) {
+      $this->loginUser($account);
+    }
+  }
+
+  /**
+   * Login user into Drupal.
+   *
+   * @param \Drupal\user\UserInterface $account
+   *   User object.
+   * @param array $extra_data
+   *   Array with optional data.
+   */
+  public function loginUser(UserInterface $account, array $extra_data = []) {
+    // Activate user if it's not.
+    if (!$account->isActive()) {
+      $account->activate();
+      $account->setPassword(user_password());
+      $account->save();
+    }
+
     // Instantiate GC login user event.
     $event = new GCUserLoginEvent($account, $extra_data);
     // Dispatch the event.
     $this->eventDispatcher->dispatch(GCUserLoginEvent::EVENT_NAME, $event);
 
     user_login_finalize($account);
-
   }
 
   /**

--- a/modules/openy_gc_auth/src/GCUserAuthorizer.php
+++ b/modules/openy_gc_auth/src/GCUserAuthorizer.php
@@ -86,7 +86,7 @@ class GCUserAuthorizer {
     }
 
     $account = NULL;
-    // Load drupal user by name and email from SalesForce.
+    // Load drupal user by name and email from Service provider.
     $account_by_mail = user_load_by_mail($mail);
     $account_by_name = user_load_by_name($name);
 
@@ -122,11 +122,13 @@ class GCUserAuthorizer {
         $account->set($changed_field, $$changed_field);
         $account->save();
 
-        $this->logger->error('Service provider user credentials was changed. For User with id:%id changed field \'%field\' from \'%old\' to \'%new\' value',
+        $this->logger->notice('Service provider user credentials was changed. For User with id:%id changed field \'%field\' from \'%old\' to \'%new\' value',
           [
             '%id' => $account->id(),
             '%field' => $changed_field,
             '%old' => $old_changed_field_value,
+            // Get field dynamically (name or mail) depend of what
+            // field was changed.
             '%new' => $$changed_field,
           ]
         );


### PR DESCRIPTION
This PR is going to improve the user authorization process. Handled 2 cases:
- user change name/email in the Service provider (daxko, prsonofy, salesforce ...) -> update drupal account according to changes + login
- user change name/email in the Service provider, but it already used in drupal -> show error message + log error.

## Steps for review:
- [ ] log in as admin
- [ ] found user (imported from sevice provider) if not present -> login through sso credentials in the incognito window /virtual-y-login
- [ ] **in admin window:** edit this user
- [ ] change email (f.e. https://i.imgur.com/qXzEgZY.png))
- [ ] **in incognito window(new session)**: /virtual-y-login -> log in through sso
- [ ] you should be redirected to the Virtual Y page
- [ ] **in admin window:** edit this user
- [ ] make sure the email updated according to SSO credentials
- [ ] visit error log page /admin/reports/dblog
- [ ] make sure changing of the field was logged https://i.imgur.com/WxEZZ2i.png
Repeat the same for username

Case if in Service provider was set email(username) that already used in Drupal:
- [ ] **in admin window**: edit user created through sso
- [ ] change email to some other https://i.imgur.com/qXzEgZY.png -> save
- [ ] create a new user with email from origin user (that was set in sso user before changes f.e. https://i.imgur.com/jg0WEnP.png)
- [ ] **in incognito window:** /virtual-y-login -> log in through sso
- [ ] you should be redirected back to Virtual Y login page and see the error https://i.imgur.com/GbWnJ3e.png
- [ ] visit error log page /admin/reports/dblog
- [ ] make sure this conflict was logged https://i.imgur.com/qsNSQN8.png

P.S. Instead of closing the incognito window (to clear session) each time and login again in through SSO, you can just logout in drupal (session in SSO should be saved and you will be immediately redirected to drupal) /user/logout