### PR TITLE
[VYMCA-134] Publishing Series Workflow Should Be Reflected in Instances

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,5 +11,12 @@
         "ext-zlib": "*"
     },
     "license": "GPL-2.0+",
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "extra": {
+        "patches": {
+            "drupal/recurring_events": {
+                "Publishing Series Workflow Should Be Reflected in Instances [3178669]": "https://www.drupal.org/files/issues/2020-10-28/recurring_events-status_changes-3178669-5.patch"
+            }
+        }
+    }
 }


### PR DESCRIPTION
**Related Issue/Ticket:**

- https://openy.atlassian.net/browse/PRODDEV-230
- https://fivejars.atlassian.net/browse/VYMCA-134

Was used the patch from this issue - https://www.drupal.org/project/recurring_events/issues/3178669

## Steps to test:

- [ ] Login as admin
- [ ] Go to `/admin/content/events/series`
- [ ] Create published test event
- [ ] Edit this event and unset `Published` field checkbox
- [ ] Press save
- [ ] Go to `/admin/content/events/instances`
- [ ] Find this event instances (you can filter by title)
- [ ] Check that all of them unpublished and not displayed on home page and schedules

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
