### PR TITLE
Update PersonifyAuthController.php to not grant access to Cancelled/Expired members

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
@@ -123,16 +123,27 @@ class PersonifyAuthController extends ControllerBase {
     $query = $request->query->all();
     if (isset($query['ct']) && !empty($query['ct'])) {
       $errorMessage = 'An attempt to login with wrong personify token was detected.';
-
+      
       $decrypted_token = $this->personifySSO->decryptCustomerToken($query['ct']);
       if ($token = $this->personifySSO->validateCustomerToken($decrypted_token)) {
-        $userInfo = $this->personifySSO->getCustomerInfo($token);
-        $errorMessage = NULL;
-        user_cookie_save([
-          'personify_authorized' => $token,
-          'personify_time' => REQUEST_TIME,
-        ]);
-      }
+		if ($this->userHasActiveMembership($token)) {
+		  $userInfo = $this->personifySSO->getCustomerInfo($token);
+          $errorMessage = NULL;
+          user_cookie_save([
+            'personify_authorized' => $token,
+            'personify_time' => REQUEST_TIME,
+          ]);		
+		} else {
+          user_cookie_delete('personify_authorized');
+          user_cookie_delete('personify_time');
+          
+          $path = URL::fromUserInput(
+            $this->configFactory->get('openy_gated_content.settings')->get('virtual_y_login_url'),
+            ['query' => ['personify-error' => '1']]
+          )->toString();
+          return new RedirectResponse($path);
+	    }
+	  }
     }
 
     // Failed auth attempt.
@@ -176,7 +187,7 @@ class PersonifyAuthController extends ControllerBase {
       // Personify user not found. Redirect to login page.
       return new RedirectResponse(Url::fromRoute('openy_gc_auth_personify.api_login_personify', [''])->toString());
     }
-
+    
     if (!$this->userHasActiveMembership($token)) {
       user_cookie_delete('personify_authorized');
       user_cookie_delete('personify_time');
@@ -187,7 +198,7 @@ class PersonifyAuthController extends ControllerBase {
       )->toString();
       return new RedirectResponse($path);
     }
-
+    
     // {"UserExists":true|false,"UserName":"","Email":"","DisableAccountFlag":false|true}.
     $userInfo = $this->personifySSO->getCustomerInfo($token);
 
@@ -247,7 +258,6 @@ class PersonifyAuthController extends ControllerBase {
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
   private function userHasActiveMembership($token) {
-
     $personifyID = $this->personifySSO->getCustomerIdentifier($token);
     if (empty($personifyID)) {
       return FALSE;
@@ -286,16 +296,15 @@ class PersonifyAuthController extends ControllerBase {
 
     $data = $this->personifyClient->doAPIcall('POST', 'GetStoredProcedureDataJSON?$format=json', $body, 'xml');
 
-    $isActive = FALSE;
-
     if ($data) {
       $results = json_decode($data['Data'], TRUE);
+
       if (isset($results['Table'][0]['Access']) && (strtolower($results['Table'][0]['Access']) === 'approved')) {
-        $isActive = TRUE;
+        return TRUE;
       }
     }
-
-    return $isActive;
+    
+    return FALSE;
   }
 
   /**
@@ -316,7 +325,7 @@ class PersonifyAuthController extends ControllerBase {
 
     // Generate auth URL that would base of validation token.
     $url = Url::fromRoute('openy_gc_auth_personify.personify_auth', [], $options)->toString();
-
+	
     $vendor_token = $this->personifySSO->getVendorToken($url);
     $options = [
       'query' => [
@@ -327,6 +336,7 @@ class PersonifyAuthController extends ControllerBase {
 
     $env = $this->configFactory->get('personify.settings')->get('environment');
     $configLoginUrl = $this->configFactory->get('openy_gc_auth_personify.settings')->get($env . '_url_login');
+	
     if (empty($configLoginUrl)) {
       $this->messenger->addWarning('Please, check Personify configs in settings.php.');
       return NULL;

--- a/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
@@ -134,8 +134,7 @@ class PersonifyAuthController extends ControllerBase {
             'personify_time' => REQUEST_TIME,
           ]);
         }
-        else
-        {
+        else {
           user_cookie_delete('personify_authorized');
           user_cookie_delete('personify_time');
 
@@ -350,4 +349,5 @@ class PersonifyAuthController extends ControllerBase {
 
     exit();
   }
+
 }

--- a/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
@@ -132,8 +132,10 @@ class PersonifyAuthController extends ControllerBase {
           user_cookie_save([
             'personify_authorized' => $token,
             'personify_time' => REQUEST_TIME,
-          ]);		
-        } else {
+          ]);
+        }
+        else
+        {
           user_cookie_delete('personify_authorized');
           user_cookie_delete('personify_time');
 
@@ -198,7 +200,7 @@ class PersonifyAuthController extends ControllerBase {
       )->toString();
       return new RedirectResponse($path);
     }
-    
+
     // {"UserExists":true|false,"UserName":"","Email":"","DisableAccountFlag":false|true}.
     $userInfo = $this->personifySSO->getCustomerInfo($token);
 
@@ -303,7 +305,7 @@ class PersonifyAuthController extends ControllerBase {
         return TRUE;
       }
     }
-    
+
     return FALSE;
   }
 

--- a/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
@@ -123,27 +123,27 @@ class PersonifyAuthController extends ControllerBase {
     $query = $request->query->all();
     if (isset($query['ct']) && !empty($query['ct'])) {
       $errorMessage = 'An attempt to login with wrong personify token was detected.';
-      
+
       $decrypted_token = $this->personifySSO->decryptCustomerToken($query['ct']);
       if ($token = $this->personifySSO->validateCustomerToken($decrypted_token)) {
-		if ($this->userHasActiveMembership($token)) {
-		  $userInfo = $this->personifySSO->getCustomerInfo($token);
+        if ($this->userHasActiveMembership($token)) {
+          $userInfo = $this->personifySSO->getCustomerInfo($token);
           $errorMessage = NULL;
           user_cookie_save([
             'personify_authorized' => $token,
             'personify_time' => REQUEST_TIME,
           ]);		
-		} else {
+        } else {
           user_cookie_delete('personify_authorized');
           user_cookie_delete('personify_time');
-          
+
           $path = URL::fromUserInput(
             $this->configFactory->get('openy_gated_content.settings')->get('virtual_y_login_url'),
             ['query' => ['personify-error' => '1']]
           )->toString();
           return new RedirectResponse($path);
-	    }
-	  }
+        }
+      }
     }
 
     // Failed auth attempt.
@@ -187,7 +187,7 @@ class PersonifyAuthController extends ControllerBase {
       // Personify user not found. Redirect to login page.
       return new RedirectResponse(Url::fromRoute('openy_gc_auth_personify.api_login_personify', [''])->toString());
     }
-    
+
     if (!$this->userHasActiveMembership($token)) {
       user_cookie_delete('personify_authorized');
       user_cookie_delete('personify_time');
@@ -325,7 +325,7 @@ class PersonifyAuthController extends ControllerBase {
 
     // Generate auth URL that would base of validation token.
     $url = Url::fromRoute('openy_gc_auth_personify.personify_auth', [], $options)->toString();
-	
+
     $vendor_token = $this->personifySSO->getVendorToken($url);
     $options = [
       'query' => [
@@ -336,7 +336,7 @@ class PersonifyAuthController extends ControllerBase {
 
     $env = $this->configFactory->get('personify.settings')->get('environment');
     $configLoginUrl = $this->configFactory->get('openy_gc_auth_personify.settings')->get($env . '_url_login');
-	
+
     if (empty($configLoginUrl)) {
       $this->messenger->addWarning('Please, check Personify configs in settings.php.');
       return NULL;
@@ -348,5 +348,4 @@ class PersonifyAuthController extends ControllerBase {
 
     exit();
   }
-
 }


### PR DESCRIPTION
Cancelled and Expired Virtual YMCA members were gaining access to Virtual Y sites that use Personify.  Fixes in auth() and userHasActiveMembership() address that problem.

Related Issue/Ticket: https://github.com/ymcatwincities/openy_gated_content/issues/114


## Steps to test:

- [ ] Use a member that has a cancelled or expired membership.
- [ ] Attempt to log in with that member.
- [ ] Login was successful when it should not have permit the member to log in. now the user will see the message with the Try Again button as seen in the following screenshot.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [X] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [X] This change does not contain front-end fixes.
- [X] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
