### PR TITLE
[PRODDEV-239] Fix field_vy_permission widget condition for non-VY content types

### DIFF
--- a/src/Plugin/Field/FieldWidget/GatedContentPermissionsFieldWidget.php
+++ b/src/Plugin/Field/FieldWidget/GatedContentPermissionsFieldWidget.php
@@ -116,7 +116,7 @@ class GatedContentPermissionsFieldWidget extends WidgetBase implements Container
   public function massageFormValues(array $values, array $form, FormStateInterface $form_state) {
 
     // Predefine right value for CT that are not using VY permissions.
-    if (array_key_first($values) === 0) {
+    if (!$form['field_vy_permission']['#access']) {
       return '';
     }
 


### PR DESCRIPTION
**Related Issue/Ticket:**

Jira - https://openy.atlassian.net/browse/PRODDEV-239
Origin issue - https://github.com/ymcatwincities/openy_gated_content/issues/110

New issue after the previous fix:

![Screenshot from 2021-02-17 18-19-11](https://user-images.githubusercontent.com/13733670/108233756-c4e92900-714c-11eb-8896-a62d4c302db2.png)


## Steps to test:

- [ ] Login as admin
- [ ] Create new VY video
- [ ] Check that `field_vy_permission` saved correctly
- [ ] Login as a dummy user and check that video displayed in the VY application
- [ ] Login as admin
- [ ] Create landing page
- [ ] Check that there no error from this issue - https://github.com/ymcatwincities/openy_gated_content/issues/110

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [x] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
