### PR TITLE
[hotfix] Use tested recurring_events version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Open Y Virtual Y Content",
     "type": "drupal-module",
     "require": {
-        "drupal/recurring_events": "*",
+        "drupal/recurring_events": "2.0.0-beta2",
         "ymcatwincities/daxko_sso": "*",
         "drupal/jsonapi_image_styles": "^1.0@beta",
         "drupal/csv_serialization": "^2.0",


### PR DESCRIPTION
**Related Issue/Ticket:**

Error in migration:
```
 [error]  DateTimeZone::__construct(): Unknown or bad timezone () (/var/www/docroot/modules/contrib/recurring_events/src/Plugin/migrate/destination/EntityEventSeries.php:69) 
```

This related to the `2.0.0-beta3` version of recurring events, that was released `24 February 2021` - https://www.drupal.org/project/recurring_events/releases/2.0.0-beta3

A related issue that broke our builds - https://www.drupal.org/project/recurring_events/issues/3196428

## Steps to test:

- [ ] Check that builds init without error
- [ ] Check that installed `2.0.0-beta2` version of recurring events
