### PR TITLE
Update PersonifyAuthController.php to not grant access to Cancelled/Expired members (master)

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_personify/openy_gc_auth_personify.services.yml
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_personify/openy_gc_auth_personify.services.yml
@@ -1,6 +1,9 @@
 services:
   gated_content_events_user_logout:
     class: '\Drupal\openy_gc_auth_personify\EventSubscriber\PersonifyUserLogoutSubscriber'
-    arguments: ['@request_stack', '@config.factory', '@logger.factory', '@http_client']
+    arguments: ['@request_stack', '@config.factory', '@openy_gc_auth_personify.client']
     tags:
       - { name: 'event_subscriber' }
+  openy_gc_auth_personify.client:
+    class: '\Drupal\openy_gc_auth_personify\Client'
+    arguments: ['@config.factory', '@logger.factory', '@http_client']

--- a/modules/openy_gc_auth/modules/openy_gc_auth_personify/openy_gc_auth_personify.services.yml
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_personify/openy_gc_auth_personify.services.yml
@@ -1,9 +1,9 @@
 services:
   gated_content_events_user_logout:
     class: '\Drupal\openy_gc_auth_personify\EventSubscriber\PersonifyUserLogoutSubscriber'
-    arguments: ['@request_stack', '@config.factory', '@openy_gc_auth_personify.client']
+    arguments: ['@request_stack', '@config.factory', '@openy_gc_auth_personify.logout_client']
     tags:
       - { name: 'event_subscriber' }
-  openy_gc_auth_personify.client:
-    class: '\Drupal\openy_gc_auth_personify\Client'
+  openy_gc_auth_personify.logout_client:
+    class: '\Drupal\openy_gc_auth_personify\LogoutClient'
     arguments: ['@config.factory', '@logger.factory', '@http_client']

--- a/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Client.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Client.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Drupal\openy_gc_auth_personify;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Logger\LoggerChannelFactory;
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use GuzzleHttp\Client as HttpClient;
+
+/**
+ * Personify provider client.
+ */
+class Client {
+
+  use StringTranslationTrait;
+
+  /**
+   * Logger interface.
+   *
+   * @var \Drupal\Core\Logger\LoggerChannelInterface
+   */
+  protected $logger;
+
+  /**
+   * Personify Config.
+   *
+   * @var \Drupal\Core\Config\Config|\Drupal\Core\Config\ImmutableConfig
+   */
+  protected $config;
+
+  /**
+   * Provider Config.
+   *
+   * @var \Drupal\Core\Config\Config|\Drupal\Core\Config\ImmutableConfig
+   */
+  protected $providerConfig;
+
+  /**
+   * The Http client.
+   *
+   * @var \GuzzleHttp\Client
+   */
+  protected $client;
+
+  /**
+   * Personify Client.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   Config factory.
+   * @param \Drupal\Core\Logger\LoggerChannelFactory $loggerChannelFactory
+   *   Logger factory.
+   * @param \GuzzleHttp\Client $client
+   *   The Http client.
+   */
+  public function __construct(
+    ConfigFactoryInterface $configFactory,
+    LoggerChannelFactory $loggerChannelFactory,
+    HttpClient $client
+  ) {
+    $this->config = $configFactory->get('personify.settings');
+    $this->providerConfig = $configFactory->get('openy_gc_auth_personify.settings');
+    $this->logger = $loggerChannelFactory->get('openy_gc_auth_personify');
+    $this->client = $client;
+  }
+
+  /**
+   * Personify Config.
+   */
+  public function getConfig() {
+    return $this->config;
+  }
+
+  /**
+   * Provider Config.
+   */
+  public function getProviderConfig() {
+    return $this->providerConfig;
+  }
+
+  /**
+   * Logout user from Personify.
+   *
+   * @param string $customerToken
+   *   Personify customer's token.
+   *
+   * @return bool
+   *   Returs TRUE when successfully logged out.
+   *
+   * @throws \GuzzleHttp\Exception\GuzzleException
+   */
+  public function logout($customerToken) {
+    $env = $this->getConfig()->get('environment');
+
+    $options = [
+      'headers' => [
+        'Content-Type' => 'application/x-www-form-urlencoded;charset=utf-8',
+        'User-Agent' => '',
+      ],
+      'auth' => [
+        $this->getConfig()->get($env . 'username'),
+        $this->getConfig()->get($env . 'password'),
+      ],
+      'verify' => FALSE,
+      'form_params' => [
+        'vendorUsername' => $this->getConfig()->get('vendor_username'),
+        'vendorPassword' => $this->getConfig()->get('vendor_password'),
+        'customerToken' => $customerToken,
+      ],
+    ];
+
+    try {
+      $endpoint = $this->getProviderConfig()->get($env . '_url_logout');
+      $response = $this->client->request('POST', $endpoint, $options);
+
+      if ($response->getStatusCode() != '200') {
+        $this->logger->error($this->t('Failed attempt to logout a user from Personify'));
+        return FALSE;
+      }
+
+      return TRUE;
+    }
+    catch (\Exception $e) {
+      $this->logger->error($e->getMessage());
+    }
+    return FALSE;
+  }
+
+}

--- a/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
@@ -123,16 +123,27 @@ class PersonifyAuthController extends ControllerBase {
     $query = $request->query->all();
     if (isset($query['ct']) && !empty($query['ct'])) {
       $errorMessage = 'An attempt to login with wrong personify token was detected.';
-
+      
       $decrypted_token = $this->personifySSO->decryptCustomerToken($query['ct']);
       if ($token = $this->personifySSO->validateCustomerToken($decrypted_token)) {
-        $userInfo = $this->personifySSO->getCustomerInfo($token);
-        $errorMessage = NULL;
-        user_cookie_save([
-          'personify_authorized' => $token,
-          'personify_time' => REQUEST_TIME,
-        ]);
-      }
+		if ($this->userHasActiveMembership($token)) {
+		  $userInfo = $this->personifySSO->getCustomerInfo($token);
+          $errorMessage = NULL;
+          user_cookie_save([
+            'personify_authorized' => $token,
+            'personify_time' => REQUEST_TIME,
+          ]);		
+		} else {
+          user_cookie_delete('personify_authorized');
+          user_cookie_delete('personify_time');
+          
+          $path = URL::fromUserInput(
+            $this->configFactory->get('openy_gated_content.settings')->get('virtual_y_login_url'),
+            ['query' => ['personify-error' => '1']]
+          )->toString();
+          return new RedirectResponse($path);
+	    }
+	  }
     }
 
     // Failed auth attempt.
@@ -176,7 +187,7 @@ class PersonifyAuthController extends ControllerBase {
       // Personify user not found. Redirect to login page.
       return new RedirectResponse(Url::fromRoute('openy_gc_auth_personify.api_login_personify', [''])->toString());
     }
-
+    
     if (!$this->userHasActiveMembership($token)) {
       user_cookie_delete('personify_authorized');
       user_cookie_delete('personify_time');
@@ -187,7 +198,7 @@ class PersonifyAuthController extends ControllerBase {
       )->toString();
       return new RedirectResponse($path);
     }
-
+    
     // {"UserExists":true|false,"UserName":"","Email":"","DisableAccountFlag":false|true}.
     $userInfo = $this->personifySSO->getCustomerInfo($token);
 
@@ -247,7 +258,6 @@ class PersonifyAuthController extends ControllerBase {
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
   private function userHasActiveMembership($token) {
-
     $personifyID = $this->personifySSO->getCustomerIdentifier($token);
     if (empty($personifyID)) {
       return FALSE;
@@ -286,16 +296,15 @@ class PersonifyAuthController extends ControllerBase {
 
     $data = $this->personifyClient->doAPIcall('POST', 'GetStoredProcedureDataJSON?$format=json', $body, 'xml');
 
-    $isActive = FALSE;
-
     if ($data) {
       $results = json_decode($data['Data'], TRUE);
+
       if (isset($results['Table'][0]['Access']) && (strtolower($results['Table'][0]['Access']) === 'approved')) {
-        $isActive = TRUE;
+        return TRUE;
       }
     }
-
-    return $isActive;
+    
+    return FALSE;
   }
 
   /**
@@ -316,7 +325,7 @@ class PersonifyAuthController extends ControllerBase {
 
     // Generate auth URL that would base of validation token.
     $url = Url::fromRoute('openy_gc_auth_personify.personify_auth', [], $options)->toString();
-
+	
     $vendor_token = $this->personifySSO->getVendorToken($url);
     $options = [
       'query' => [
@@ -327,6 +336,7 @@ class PersonifyAuthController extends ControllerBase {
 
     $env = $this->configFactory->get('personify.settings')->get('environment');
     $configLoginUrl = $this->configFactory->get('openy_gc_auth_personify.settings')->get($env . '_url_login');
+	
     if (empty($configLoginUrl)) {
       $this->messenger->addWarning('Please, check Personify configs in settings.php.');
       return NULL;

--- a/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
@@ -134,8 +134,7 @@ class PersonifyAuthController extends ControllerBase {
             'personify_time' => REQUEST_TIME,
           ]);
         }
-        else
-        {
+        else {
           user_cookie_delete('personify_authorized');
           user_cookie_delete('personify_time');
 
@@ -350,4 +349,5 @@ class PersonifyAuthController extends ControllerBase {
 
     exit();
   }
+
 }

--- a/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\openy_gc_auth\GCUserAuthorizer;
-use Drupal\openy_gc_auth_personify\Client as ProviderClient;
+use Drupal\openy_gc_auth_personify\LogoutClient;
 
 /**
  * Personify controller to handle Personify SSO authentication.
@@ -75,9 +75,9 @@ class PersonifyAuthController extends ControllerBase {
   /**
    * Provider client.
    *
-   * @var \Drupal\openy_gc_auth_personify\Client
+   * @var \Drupal\openy_gc_auth_personify\LogoutClient
    */
-  protected $providerClient;
+  protected $logoutClient;
 
   /**
    * PersonifyAuthController constructor.
@@ -96,8 +96,8 @@ class PersonifyAuthController extends ControllerBase {
    *   The Gated User Authorizer.
    * @param \Drupal\Component\EventDispatcher\ContainerAwareEventDispatcher $eventDispatcher
    *   Event Dispatcher.
-   * @param \Drupal\openy_gc_auth_personify\Client $providerClient
-   *   Provider client.
+   * @param \Drupal\openy_gc_auth_personify\LogoutClient $logoutClient
+   *   Logout client.
    */
   public function __construct(
     PersonifySSO $personifySSO,
@@ -107,7 +107,7 @@ class PersonifyAuthController extends ControllerBase {
     MessengerInterface $messenger,
     GCUserAuthorizer $gcUserAuthorizer,
     ContainerAwareEventDispatcher $eventDispatcher,
-    ProviderClient $providerClient
+    LogoutClient $logoutClient
   ) {
     $this->personifySSO = $personifySSO;
     $this->personifyClient = $personifyClient;
@@ -116,7 +116,7 @@ class PersonifyAuthController extends ControllerBase {
     $this->messenger = $messenger;
     $this->gcUserAuthorizer = $gcUserAuthorizer;
     $this->eventDispatcher = $eventDispatcher;
-    $this->providerClient = $providerClient;
+    $this->logoutClient = $logoutClient;
   }
 
   /**
@@ -131,7 +131,7 @@ class PersonifyAuthController extends ControllerBase {
       $container->get('messenger'),
       $container->get('openy_gc_auth.user_authorizer'),
       $container->get('event_dispatcher'),
-      $container->get('openy_gc_auth_personify.client')
+      $container->get('openy_gc_auth_personify.logout_client')
     );
   }
 
@@ -161,7 +161,7 @@ class PersonifyAuthController extends ControllerBase {
           ]);
         }
         else {
-          $isUserSuccessfullyLogout = $this->providerClient->logout($token);
+          $isUserSuccessfullyLogout = $this->logoutClient->logout($token);
           if ($isUserSuccessfullyLogout) {
             user_cookie_delete('personify_authorized');
             user_cookie_delete('personify_time');

--- a/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
@@ -132,8 +132,10 @@ class PersonifyAuthController extends ControllerBase {
           user_cookie_save([
             'personify_authorized' => $token,
             'personify_time' => REQUEST_TIME,
-          ]);		
-        } else {
+          ]);
+        }
+        else
+        {
           user_cookie_delete('personify_authorized');
           user_cookie_delete('personify_time');
 
@@ -198,7 +200,7 @@ class PersonifyAuthController extends ControllerBase {
       )->toString();
       return new RedirectResponse($path);
     }
-    
+
     // {"UserExists":true|false,"UserName":"","Email":"","DisableAccountFlag":false|true}.
     $userInfo = $this->personifySSO->getCustomerInfo($token);
 
@@ -303,7 +305,7 @@ class PersonifyAuthController extends ControllerBase {
         return TRUE;
       }
     }
-    
+
     return FALSE;
   }
 

--- a/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
@@ -123,27 +123,27 @@ class PersonifyAuthController extends ControllerBase {
     $query = $request->query->all();
     if (isset($query['ct']) && !empty($query['ct'])) {
       $errorMessage = 'An attempt to login with wrong personify token was detected.';
-      
+
       $decrypted_token = $this->personifySSO->decryptCustomerToken($query['ct']);
       if ($token = $this->personifySSO->validateCustomerToken($decrypted_token)) {
-		if ($this->userHasActiveMembership($token)) {
-		  $userInfo = $this->personifySSO->getCustomerInfo($token);
+        if ($this->userHasActiveMembership($token)) {
+          $userInfo = $this->personifySSO->getCustomerInfo($token);
           $errorMessage = NULL;
           user_cookie_save([
             'personify_authorized' => $token,
             'personify_time' => REQUEST_TIME,
           ]);		
-		} else {
+        } else {
           user_cookie_delete('personify_authorized');
           user_cookie_delete('personify_time');
-          
+
           $path = URL::fromUserInput(
             $this->configFactory->get('openy_gated_content.settings')->get('virtual_y_login_url'),
             ['query' => ['personify-error' => '1']]
           )->toString();
           return new RedirectResponse($path);
-	    }
-	  }
+        }
+      }
     }
 
     // Failed auth attempt.
@@ -187,7 +187,7 @@ class PersonifyAuthController extends ControllerBase {
       // Personify user not found. Redirect to login page.
       return new RedirectResponse(Url::fromRoute('openy_gc_auth_personify.api_login_personify', [''])->toString());
     }
-    
+
     if (!$this->userHasActiveMembership($token)) {
       user_cookie_delete('personify_authorized');
       user_cookie_delete('personify_time');
@@ -325,7 +325,7 @@ class PersonifyAuthController extends ControllerBase {
 
     // Generate auth URL that would base of validation token.
     $url = Url::fromRoute('openy_gc_auth_personify.personify_auth', [], $options)->toString();
-	
+
     $vendor_token = $this->personifySSO->getVendorToken($url);
     $options = [
       'query' => [
@@ -336,7 +336,7 @@ class PersonifyAuthController extends ControllerBase {
 
     $env = $this->configFactory->get('personify.settings')->get('environment');
     $configLoginUrl = $this->configFactory->get('openy_gc_auth_personify.settings')->get($env . '_url_login');
-	
+
     if (empty($configLoginUrl)) {
       $this->messenger->addWarning('Please, check Personify configs in settings.php.');
       return NULL;
@@ -348,5 +348,4 @@ class PersonifyAuthController extends ControllerBase {
 
     exit();
   }
-
 }

--- a/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/Controller/PersonifyAuthController.php
@@ -161,7 +161,11 @@ class PersonifyAuthController extends ControllerBase {
           ]);
         }
         else {
-          $this->providerClient->logout($token);
+          $isUserSuccessfullyLogout = $this->providerClient->logout($token);
+          if ($isUserSuccessfullyLogout) {
+            user_cookie_delete('personify_authorized');
+            user_cookie_delete('personify_time');
+          }
 
           $path = URL::fromUserInput(
             $this->configFactory->get('openy_gated_content.settings')->get('virtual_y_login_url'),

--- a/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/EventSubscriber/PersonifyUserLogoutSubscriber.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/EventSubscriber/PersonifyUserLogoutSubscriber.php
@@ -3,12 +3,10 @@
 namespace Drupal\openy_gc_auth_personify\EventSubscriber;
 
 use Drupal\Core\Config\ConfigFactoryInterface;
-use Drupal\Core\Logger\LoggerChannelFactory;
 use Drupal\openy_gc_auth\Event\GCUserLogoutEvent;
-use GuzzleHttp\Client;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\openy_gc_auth_personify\Client;
 
 /**
  * Class PersonifyUserLogoutSubscriber Subscriber.
@@ -16,8 +14,6 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
  * @package Drupal\openy_gc_auth_personify\EventSubscriber
  */
 class PersonifyUserLogoutSubscriber implements EventSubscriberInterface {
-
-  use StringTranslationTrait;
 
   /**
    * The current request.
@@ -27,13 +23,6 @@ class PersonifyUserLogoutSubscriber implements EventSubscriberInterface {
   protected $currentRequest;
 
   /**
-   * Logger interface.
-   *
-   * @var \Drupal\Core\Logger\LoggerChannelInterface
-   */
-  protected $logger;
-
-  /**
    * Config factory.
    *
    * @var \Drupal\Core\Config\ConfigFactoryInterface
@@ -41,9 +30,9 @@ class PersonifyUserLogoutSubscriber implements EventSubscriberInterface {
   protected $configFactory;
 
   /**
-   * The Http client.
+   * Personify Client.
    *
-   * @var \GuzzleHttp\Client
+   * @var \Drupal\openy_gc_auth_personify\Client
    */
   protected $client;
 
@@ -54,20 +43,16 @@ class PersonifyUserLogoutSubscriber implements EventSubscriberInterface {
    *   The request stack.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   Config factory.
-   * @param \Drupal\Core\Logger\LoggerChannelFactory $loggerChannelFactory
-   *   Logger factory.
-   * @param \GuzzleHttp\Client $client
-   *   The Http client.
+   * @param \Drupal\openy_gc_auth_personify\Client $client
+   *   Personify Client.
    */
   public function __construct(
     RequestStack $requestStack,
     ConfigFactoryInterface $configFactory,
-    LoggerChannelFactory $loggerChannelFactory,
     Client $client
   ) {
     $this->currentRequest = $requestStack->getCurrentRequest();
     $this->configFactory = $configFactory;
-    $this->logger = $loggerChannelFactory->get('openy_gc_auth_personify');
     $this->client = $client;
   }
 
@@ -97,7 +82,7 @@ class PersonifyUserLogoutSubscriber implements EventSubscriberInterface {
         return FALSE;
       }
 
-      $isUserSuccessfullyLogout = $this->apiLogout($token);
+      $isUserSuccessfullyLogout = $this->client->logout($token);
       if ($isUserSuccessfullyLogout) {
         user_cookie_delete('personify_authorized');
         user_cookie_delete('personify_time');
@@ -105,54 +90,6 @@ class PersonifyUserLogoutSubscriber implements EventSubscriberInterface {
       }
       return FALSE;
     }
-  }
-
-  /**
-   * Logout user from Personify.
-   *
-   * @param string $customerToken
-   *   Personify customer's token.
-   *
-   * @throws \GuzzleHttp\Exception\GuzzleException
-   */
-  public function apiLogout($customerToken) {
-    $settings = $this->configFactory->get('personify.settings');
-    $env = $settings->get('environment');
-
-    $options = [
-      'headers' => [
-        'Content-Type' => 'application/x-www-form-urlencoded;charset=utf-8',
-        'User-Agent' => '',
-      ],
-      'auth' => [
-        $settings->get($env . 'username'),
-        $settings->get($env . 'password'),
-      ],
-      'verify' => FALSE,
-      'form_params' => [
-        'vendorUsername' => $settings->get('vendor_username'),
-        'vendorPassword' => $settings->get('vendor_password'),
-        'customerToken' => $customerToken,
-      ],
-    ];
-
-    try {
-
-      $endpoint = $this->configFactory->get('openy_gc_auth_personify.settings')->get($env . '_url_logout');
-
-      $response = $this->client->request('POST', $endpoint, $options);
-
-      if ($response->getStatusCode() != '200') {
-        $this->logger->error($this->t('Failed attempt to logout a user from Personify'));
-        return FALSE;
-      }
-
-      return TRUE;
-    }
-    catch (\Exception $e) {
-      $this->logger->error($e->getMessage());
-    }
-    return FALSE;
   }
 
 }

--- a/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/EventSubscriber/PersonifyUserLogoutSubscriber.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/EventSubscriber/PersonifyUserLogoutSubscriber.php
@@ -6,7 +6,7 @@ use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\openy_gc_auth\Event\GCUserLogoutEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
-use Drupal\openy_gc_auth_personify\Client;
+use Drupal\openy_gc_auth_personify\LogoutClient;
 
 /**
  * Class PersonifyUserLogoutSubscriber Subscriber.
@@ -32,9 +32,9 @@ class PersonifyUserLogoutSubscriber implements EventSubscriberInterface {
   /**
    * Personify Client.
    *
-   * @var \Drupal\openy_gc_auth_personify\Client
+   * @var \Drupal\openy_gc_auth_personify\LogoutClient
    */
-  protected $client;
+  protected $logoutClient;
 
   /**
    * Constructs a new PersonifyUserLogoutSubscriber.
@@ -43,17 +43,17 @@ class PersonifyUserLogoutSubscriber implements EventSubscriberInterface {
    *   The request stack.
    * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
    *   Config factory.
-   * @param \Drupal\openy_gc_auth_personify\Client $client
-   *   Personify Client.
+   * @param \Drupal\openy_gc_auth_personify\LogoutClient $logoutClient
+   *   Personify Logout Client.
    */
   public function __construct(
     RequestStack $requestStack,
     ConfigFactoryInterface $configFactory,
-    Client $client
+    LogoutClient $logoutClient
   ) {
     $this->currentRequest = $requestStack->getCurrentRequest();
     $this->configFactory = $configFactory;
-    $this->client = $client;
+    $this->logoutClient = $logoutClient;
   }
 
   /**
@@ -82,7 +82,7 @@ class PersonifyUserLogoutSubscriber implements EventSubscriberInterface {
         return FALSE;
       }
 
-      $isUserSuccessfullyLogout = $this->client->logout($token);
+      $isUserSuccessfullyLogout = $this->logoutClient->logout($token);
       if ($isUserSuccessfullyLogout) {
         user_cookie_delete('personify_authorized');
         user_cookie_delete('personify_time');

--- a/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/LogoutClient.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_personify/src/LogoutClient.php
@@ -8,9 +8,9 @@ use Drupal\Core\StringTranslation\StringTranslationTrait;
 use GuzzleHttp\Client as HttpClient;
 
 /**
- * Personify provider client.
+ * Personify logout client.
  */
-class Client {
+class LogoutClient {
 
   use StringTranslationTrait;
 


### PR DESCRIPTION
Canceled and Expired Virtual YMCA members were gaining access to Virtual Y sites that use Personify.  Fixes in auth() and userHasActiveMembership() address that problem.

Related Issue/Ticket: https://github.com/ymcatwincities/openy_gated_content/issues/114

Cherry-picked from https://github.com/fivejars/openy_gated_content/pull/271

## Steps to test:

- [ ] Use a member that has a canceled or expired membership.
- [ ] Attempt to log in with that member.
- [ ] Login was successful when it should not have permitted the member to log in. now the user will see the message with the Try Again button as seen in the following screenshot.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [X] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [X] This change does not contain front-end fixes.
- [X] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
