### PR TITLE
ReClique: Default role to Virtual YMCA if no mapping (to 1.3)

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique/src/EventSubscriber/GCAuthReCliqueUserLoginSubscriber.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique/src/EventSubscriber/GCAuthReCliqueUserLoginSubscriber.php
@@ -66,13 +66,23 @@ class GCAuthReCliqueUserLoginSubscriber implements EventSubscriberInterface {
             }
           }
           $user_membership = $event->extraData['member']['PackageName'];
+          $user_memberships = $event->extraData['Memberships'];
+          $active_roles = [];
           $permissions_mapping = explode(';', $permissions_mapping);
           foreach ($permissions_mapping as $mapping) {
             $role = explode(':', $mapping);
             // Compare mapping roles with user membership.
-            if (isset($role[0]) && $role[0] == $user_membership && isset($role[1])) {
-              $account->addRole($role[1]);
+            foreach ($user_memberships as $user_membership) {
+              if (isset($role[0]) && $role[0] == $user_membership && isset($role[1])) {
+                $account->addRole($role[1]);
+              }
             }
+          }
+          if (empty($active_roles)) {
+            $active_roles = ['virtual_y'];
+          }
+          foreach ($active_roles as $role) {
+            $account->addRole($role);
           }
           $account->save();
         }


### PR DESCRIPTION
For ReClique CORE CRM Y's, Virtual YMCA role should be the default new user role if no Permissions Mapping defined.

**Related Issue/Ticket:** https://github.com/ymcatwincities/openy_gated_content/issues/122

**PLEASE CHECK BASE BRANCH FOR YOUR PR**
**ONLY urgent and approved fixes for point release should go to master branch**

https://github.com/ymcatwincities/openy_gated_content/issues/122

## Steps to test:

- Go to https://northpennymca-azure-stage.y.org (or equivalent Virtual Y site that uses ReClique CORE crm).
- Verify there are no Permission Mappings present in the Reclique authentication provider configuration.
- Create a new user in the system by logging in with an member's email address for that that is not already in the system
- example used for North Penn: nan_dec@yahoo.com.
- If this user is already present in People, delete that user from People to enable the test.
- Upon login, the member should be able to access any and all Virtual Y content. An administrator should see in People that the new user is assigned the Virtual YMCA role.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [X] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [X] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
