### PR TITLE
[PRODDEV-243] Add missed dependencies

### DIFF
--- a/modules/openy_gc_demo/openy_gc_demo.info.yml
+++ b/modules/openy_gc_demo/openy_gc_demo.info.yml
@@ -16,3 +16,6 @@ dependencies:
   - drupal:openy_gc_storage
   - drupal:openy_gc_auth_example
   - drupal:openy_demo_tcolor
+  - drupal:openy_node_landing
+  - drupal:openy_prgf_banner
+  - drupal:openy_prgf_simple_content


### PR DESCRIPTION
**Related Issue/Ticket:**

https://openy.atlassian.net/browse/PRODDEV-243

```
Error: Call to a member function getEnabledBehaviorPlugins() on null in Drupal\paragraphs\ParagraphViewBuilder->buildMultiple() (line 37 of /var/www/docroot/modules/contrib/paragraphs/src/ParagraphViewBuilder.php) 
```

On the drupal 9 demo, we have this error because the banner module disabled

## Steps to test:

- [ ] No need to test this

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [x] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
