### PR TITLE
[PRODDEV-229] Fix referer header for shared content

### DIFF
--- a/modules/openy_gc_shared_content/src/SharedContentSourceTypeBase.php
+++ b/modules/openy_gc_shared_content/src/SharedContentSourceTypeBase.php
@@ -213,7 +213,7 @@ class SharedContentSourceTypeBase extends PluginBase implements SharedContentSou
           'headers' => [
             'Content-Type' => 'application/json',
             'Accept' => 'application/json',
-            'Referer' => $this->requestStack->getSchemeAndHttpHost(),
+            'x-shared-referer' => $this->requestStack->getSchemeAndHttpHost(),
             'Authorization' => 'Bearer ' . $shared_content_server->getToken(),
             'X-Shared-Content' => TRUE,
           ],


### PR DESCRIPTION
**Related Issue/Ticket:**

Fix for https://github.com/fivejars/openy_gated_content/pull/287/files#diff-30bce3358885c1e6f9f8561df51ccb508a29a5045346116d778fb071571ac073R179

## Steps to test:

- [ ] Sheck that shared content fetch works
- [ ] Use steps from https://github.com/fivejars/openy_gated_content/pull/173 + approve client on the shared server side

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [x] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
