### PR TITLE
Fix duplicate logs in export files

### DIFF
--- a/modules/openy_gc_log/openy_gc_log.module
+++ b/modules/openy_gc_log/openy_gc_log.module
@@ -36,7 +36,9 @@ function openy_gc_log_preprocess_views_view(array &$variables) {
  * Implements hook_cron().
  */
 function openy_gc_log_cron() {
-  \Drupal::service("openy_gc_log.log_archiver")->archive();
+  $archiver = \Drupal::service("openy_gc_log.log_archiver");
+  $archiver->setWorkerChunkSize(600);
+  $archiver->archive();
 }
 
 /**

--- a/modules/openy_gc_log/src/LogArchiver.php
+++ b/modules/openy_gc_log/src/LogArchiver.php
@@ -61,6 +61,13 @@ class LogArchiver {
   protected $fileEntities;
 
   /**
+   * Limit log entities count loaded by current process.
+   *
+   * @var int
+   */
+  protected $workerChunkSize = NULL;
+
+  /**
    * Entity Type Manager to work with.
    *
    * @var \Drupal\Core\Entity\EntityTypeManager
@@ -194,52 +201,92 @@ class LogArchiver {
     }
     $start_time = $start->getTimestamp();
 
-    $query = $this->entityTypeManager->getStorage('log_entity')
-      ->getQuery()
-      ->condition('created', [$start_time, $end_time], 'BETWEEN')
-      ->sort('created', 'ASC');
-    if (!isset($start) && !isset($end)) {
-      $query->range(0, self::WORKER_CHUNK_SIZE);
-    }
-    $log_ids = $query->execute();
+    $log_ids = $this->loadLogIdsByDataRange($start_time, $end_time);
 
     if (empty($log_ids)) {
       return;
     }
 
-    $this->setLogIds($log_ids)
-      ->loadLogEntities()
-      ->prepareLogsForExport($filename)
-      ->loadFileEntities()
-      ->writeLogsToFiles()
-      ->saveFileEntities()
-      ->reportToDbLog();
+    $activity_log_ids = $this->loadActivityLogIdsByDateRange($start_time, $end_time);
 
+    if ($log_ids) {
+      $this->loadLogEntities($log_ids);
+      $this->prepareLogsForExport($filename);
+    }
+
+    if ($activity_log_ids) {
+      $this->loadActivityLogEntities($activity_log_ids);
+      $this->prepareActivityLogsForExport($activity_filename);
+    }
+
+    $this->loadFileEntities();
+    $this->writeLogsToFiles();
+    $this->saveFileEntities();
+    $this->reportToDbLog();
+
+    if ($remove_entities) {
+      $this->removeLogsFromDb();
+    }
+  }
+
+  /**
+   * Limit log entities count loaded by current process.
+   *
+   * @param int $chunk_size
+   *   Chunk Size.
+   */
+  public function setWorkerChunkSize($chunk_size) {
+    $this->workerChunkSize = $chunk_size;
+  }
+
+  /**
+   * Build, run query and return log ids array.
+   *
+   * @param int $start_time
+   *   Timestamp.
+   * @param int $end_time
+   *   Timestamp.
+   *
+   * @return array|int
+   *   Logs ids.
+   */
+  protected function loadLogIdsByDataRange($start_time, $end_time) {
+    $query = $this->entityTypeManager
+      ->getStorage('log_entity')
+      ->getQuery()
+      ->condition('created', [$start_time, $end_time], 'BETWEEN')
+      ->sort('created', 'ASC');
+
+    if ($this->workerChunkSize > 0) {
+      $query->range(0, $this->workerChunkSize);
+    }
+
+    return $query->execute();
+  }
+
+  /**
+   * Build, run query and return activity log ids array.
+   *
+   * @param int $start_time
+   *   Timestamp.
+   * @param int $end_time
+   *   Timestamp.
+   *
+   * @return array|int
+   *   Logs ids array.
+   */
+  protected function loadActivityLogIdsByDateRange($start_time, $end_time) {
     $query = $this->entityTypeManager->getStorage('log_entity')
       ->getQuery()
       ->condition('event_type', LogEntityInterface::EVENT_TYPE_USER_ACTIVITY)
       ->condition('created', [$start_time, $end_time], 'BETWEEN')
       ->sort('created', 'ASC');
-    if (!isset($start) && !isset($end)) {
-      $query->range(0, self::WORKER_CHUNK_SIZE);
-    }
-    $log_ids = $query->execute();
 
-    if (empty($log_ids)) {
-      return;
+    if ($this->workerChunkSize > 0) {
+      $query->range(0, $this->workerChunkSize);
     }
 
-    $this->setLogIds($log_ids)
-      ->loadActivityLogEntities()
-      ->prepareActivityLogsForExport($activity_filename)
-      ->loadFileEntities()
-      ->writeLogsToFiles()
-      ->saveFileEntities()
-      ->reportToDbLog();
-
-    if ($remove_entities) {
-      $this->removeLogsFromDb();
-    }
+    return $query->execute();
   }
 
   /**
@@ -253,22 +300,28 @@ class LogArchiver {
 
   /**
    * Load log entities.
+   *
+   * @param array $log_ids
+   *   Log ids.
    */
-  protected function loadLogEntities() {
+  protected function loadLogEntities(array $log_ids) {
     $this->logEntities = $this->entityTypeManager
       ->getStorage('log_entity')
-      ->loadMultiple($this->logIds);
+      ->loadMultiple($log_ids);
 
     return $this;
   }
 
   /**
    * Load activity log entities.
+   *
+   * @param array $log_ids
+   *   Log ids.
    */
-  protected function loadActivityLogEntities() {
+  protected function loadActivityLogEntities(array $log_ids) {
     $this->activityLogEntities = $this->entityTypeManager
       ->getStorage('log_entity')
-      ->loadMultiple($this->logIds);
+      ->loadMultiple($log_ids);
 
     return $this;
   }
@@ -542,9 +595,10 @@ class LogArchiver {
    */
   protected function reportToDbLog() {
     $this->logger->debug(
-      'Virtual Y Logs processed into archive: %count entities.',
+      'Virtual Y Logs processed into archive: %count entities (%activity_count activity).',
       [
-        '%count' => count($this->logIds),
+        '%count' => count($this->logEntities),
+        '%activity_count' => count($this->activityLogEntities),
       ]
     );
 


### PR DESCRIPTION
**Related Issue/Ticket:**

PRODDEV-263

Additional change in this PR is related to

`if (!isset($start) && !isset($end)) {
      $query->range(0, self::WORKER_CHUNK_SIZE);
}`

This code was not reachable, so I changed the way this limit works by introducing new function _setWorkerChunkSize_ which is called from cron handler.

## Steps to test:

- [ ] Log in as an admin
- [ ] Enable "Open Y Virtual YMCA Log" module
- [ ] Navigate through the site
- [ ] In the incognito browser mode or another browser log in as a common VY user
- [ ] Navigate through the site again
- [ ] Ensure the logs are displayed on the /admin/virtual-y-logs page
- [ ] Export the logs
- [ ] See report

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [x] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
