### PR TITLE
Wrap the call to create a new Y-USA Provider user in a try...catch

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_yusa/src/Form/VirtualYUSALoginForm.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_yusa/src/Form/VirtualYUSALoginForm.php
@@ -241,9 +241,14 @@ class VirtualYUSALoginForm extends FormBase {
         $user = reset($users);
 
         // Create a new user in DB.
-        if (!$user) {
-          $active = TRUE;
-          $user = $this->gcUserAuthorizer->createUser($name, $email, $active);
+        try {
+          if (!$user) {
+            $active = TRUE;
+            $user = $this->gcUserAuthorizer->createUser($name, $email, $active);
+          }
+        }
+        catch (\Exception $e) {
+          $this->messenger()->addError($this->t('Something went wrong. Please try again.'));
         }
 
         if ($user instanceof User) {


### PR DESCRIPTION
Wrap the call to create a new user in sites using Y-USA Provider in a try...catch so the current unhandled exception returned when there is a mismatch between NWM and Daxko when a barcode is entered, and Virtual Y attempts to create a new user for a new barcode.


**Related Issue/Ticket:**

**PLEASE CHECK BASE BRANCH FOR YOUR PR**
**ONLY urgent and approved fixes for point release should go to master branch**

https://github.com/ymcatwincities/openy_gated_content/issues/132

## Steps to test:

- [ ] Arrange a user in a site using the Y-USA Provider so that Nationwide Membership reflects a different barcode for a user than what is entered in existing user the Virtual Y People tab.
- [ ] Attempt a sign-in for that user using the updated barcode value.
- [ ] The user will see a standard sign-in error stating "Something went wrong. Please try again." instead of the dreaded "White screen of death".

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [X] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [X] Tested against Carnation
  - [X] Tested against Lily
  - [X] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
