### PR TITLE
[PRODDEV-271] Make logs headers and content more human readable

### DIFF
--- a/modules/openy_gc_log/config/install/views.view.virtual_y_logs.yml
+++ b/modules/openy_gc_log/config/install/views.view.virtual_y_logs.yml
@@ -140,7 +140,7 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Created
+          label: Date
           exclude: false
           alter:
             alter_text: false
@@ -272,7 +272,7 @@ display:
           relationship: uid
           group_type: group
           admin_label: ''
-          label: 'User Name'
+          label: Member
           exclude: false
           alter:
             alter_text: false
@@ -340,8 +340,8 @@ display:
           label: 'Event Type'
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: "{% if event_type__value == 'userLoggedIn' %}\r\n  Member logged in\r\n{% elseif event_type__value == 'entityView' %}\r\n  Viewed content\r\n{% elseif event_type__value == 'videoPlaybackStarted' %}\r\n  Video started\r\n{% elseif event_type__value == 'videoPlaybackEnded' %}\r\n  Video end reached\r\n{% elseif event_type__value == 'userActivity' %}\r\n  Member activity detected\r\n{% else %}\r\n  {{ event_type__value }}\r\n{% endif %}"
             make_link: false
             path: ''
             absolute: false
@@ -402,11 +402,11 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: 'Entity Type'
+          label: 'Content Type'
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: '{{ entity_type__value == ''node'' ? ''Ondemand'' : ''Live event'' }}'
             make_link: false
             path: ''
             absolute: false
@@ -467,11 +467,11 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: Bundle
+          label: 'Content Class'
           exclude: false
           alter:
-            alter_text: false
-            text: ''
+            alter_text: true
+            text: '{{ entity_bundle__value == ''gc_video'' ? ''vy_video'' : entity_bundle__value }}'
             make_link: false
             path: ''
             absolute: false
@@ -532,8 +532,8 @@ display:
           relationship: none
           group_type: group
           admin_label: ''
-          label: 'Entity Id'
-          exclude: true
+          label: 'Content Drupal ID'
+          exclude: false
           alter:
             alter_text: false
             text: ''
@@ -724,7 +724,7 @@ display:
           exposed: true
           expose:
             operator_id: created_op
-            label: 'Date Start'
+            label: 'Date From'
             description: 'Format: YYYY-MM-DD HH:MM:SS'
             use_operator: false
             operator: created_op
@@ -901,23 +901,23 @@ display:
             default_group_multiple: {  }
             group_items:
               1:
-                title: userLoggedIn
+                title: 'Member logged in'
                 operator: contains
                 value: userLoggedIn
               2:
-                title: entityView
+                title: 'Viewed content'
                 operator: contains
                 value: entityView
               3:
-                title: videoPlaybackStarted
+                title: 'Video started'
                 operator: contains
                 value: videoPlaybackStarted
               4:
-                title: videoPlaybackEnded
+                title: 'Video end reached'
                 operator: contains
                 value: videoPlaybackEnded
               5:
-                title: userActivity
+                title: 'Member activity detected'
                 operator: contains
                 value: userActivity
           entity_type: log_entity
@@ -955,7 +955,7 @@ display:
             placeholder: ''
           is_grouped: true
           group_info:
-            label: 'Entity Type'
+            label: 'Content Type'
             description: ''
             identifier: entity_type
             optional: true
@@ -966,11 +966,11 @@ display:
             default_group_multiple: {  }
             group_items:
               1:
-                title: Video/Blog
+                title: Ondemand
                 operator: contains
                 value: node
               2:
-                title: 'Videoconference/Online Translation'
+                title: 'Live event'
                 operator: contains
                 value: series
               3:
@@ -1012,7 +1012,7 @@ display:
             placeholder: ''
           is_grouped: true
           group_info:
-            label: Bundle
+            label: 'Content Class'
             description: ''
             identifier: entity_bundle
             optional: true
@@ -1244,7 +1244,7 @@ display:
           relationship: uid
           group_type: group
           admin_label: ''
-          label: 'User Name'
+          label: Member
           exclude: false
           alter:
             alter_text: false
@@ -1517,7 +1517,7 @@ display:
           exposed: true
           expose:
             operator_id: uid_op
-            label: 'User Name'
+            label: Member
             description: ''
             use_operator: false
             operator: uid_op

--- a/modules/openy_gc_log/openy_gc_log.api.php
+++ b/modules/openy_gc_log/openy_gc_log.api.php
@@ -17,10 +17,10 @@ use Drupal\openy_gc_log\Entity\LogEntityInterface;
  */
 function hook_openy_gc_log_export_row_alter(array &$export_row, LogEntityInterface $log) {
   // Add the user ID to an export.
-  $export_row['user_id'] = $log->get('uid')->target_id;
+  $export_row['Drupal User ID'] = $log->get('uid')->target_id;
 
   // Remove the users' emails from an export.
-  unset($export_row['user']);
+  unset($export_row['Member']);
 }
 
 /**
@@ -33,8 +33,8 @@ function hook_openy_gc_log_export_row_alter(array &$export_row, LogEntityInterfa
  */
 function hook_openy_gc_activity_log_export_row(array &$export_row, LogEntityInterface $log) {
   // Add the user ID to an export.
-  $export_row['user_id'] = $log->get('uid')->target_id;
+  $export_row['Drupal User ID'] = $log->get('uid')->target_id;
 
   // Remove the users' emails from an export.
-  unset($export_row['user']);
+  unset($export_row['Member']);
 }

--- a/modules/openy_gc_log/openy_gc_log.install
+++ b/modules/openy_gc_log/openy_gc_log.install
@@ -173,3 +173,16 @@ function openy_gc_log_update_8009() {
     'views.view.virtual_y_logs',
   ]);
 }
+
+/**
+ * Import updated logs view config.
+ */
+function openy_gc_log_update_8010() {
+  $config_dir = drupal_get_path('module', 'openy_gc_log');
+  $config_dir .= '/config/install/';
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'views.view.virtual_y_logs',
+  ]);
+}

--- a/modules/openy_gc_log/src/LogArchiver.php
+++ b/modules/openy_gc_log/src/LogArchiver.php
@@ -391,17 +391,24 @@ class LogArchiver {
       $user_data = $log->get('uid')->target_id && ($log->get('uid')->entity instanceof UserInterface) ?
       $log->get('uid')->entity->getEmail() :
       $log->get('email')->value;
+      $event_types = [
+        'userLoggedIn' => 'Member logged in',
+        'entityView' => 'Viewed content',
+        'videoPlaybackStarted' => 'Video started',
+        'videoPlaybackEnded' => 'Video end reached',
+        'userActivity' => 'Member activity detected',
+      ];
       $export_row = [
-        'created' => date('m/d/Y - H:i:s', $log->get('created')->value),
-        'user' => $user_data,
-        'event_type' => $event_type,
-        'entity_type' => $entity_type,
-        'entity_bundle' => $entity_bundle,
-        'entity_id' => $entity_id,
-        'entity_title' => '',
-        'entity_instructor_name' => '',
-        'entity_created' => '',
-        'activity_duration' => '',
+        'Date' => date('m/d/Y - H:i:s', $log->get('created')->value),
+        'Member' => $user_data,
+        'Event type' => $event_types[$event_type] ?: $event_type,
+        'Content type' => $entity_type === 'node' ? 'Ondemand' : 'Live event',
+        'Content class' => $entity_bundle === 'gc_video' ? 'vy_video' : $entity_bundle,
+        'Content Drupal ID' => $entity_id,
+        'Content title' => '',
+        'Instructor name' => '',
+        'Content creation date' => '',
+        'Activity duration' => '',
       ];
 
       switch ($event_type) {
@@ -413,19 +420,19 @@ class LogArchiver {
             $metadata = unserialize($log->get('event_metadata')->value, ['allowed_classes' => FALSE]);
           }
           foreach ([
-            'entity_title',
-            'entity_instructor_name',
-            'entity_created',
-          ] as $key) {
+            'entity_title' => 'Content title',
+            'entity_instructor_name' => 'Instructor name',
+            'entity_created' => 'Content creation date',
+          ] as $key => $export_col) {
             if (!array_key_exists($key, $metadata)) {
               continue 1;
             }
-            $export_row[$key] = $metadata[$key];
+            $export_row[$export_col] = $metadata[$key];
           }
           break;
 
         case LogEntityInterface::EVENT_TYPE_USER_ACTIVITY:
-          $export_row['activity_duration'] = $this->dateFormatter->formatDiff($log->getCreatedTime(), $log->getChangedTime());
+          $export_row['Activity duration'] = $this->dateFormatter->formatDiff($log->getCreatedTime(), $log->getChangedTime());
           break;
       }
 
@@ -467,9 +474,9 @@ class LogArchiver {
         $log->get('email')->value;
       $date = date('m/d/Y', $log->get('created')->value);
       $export_row = [
-        'created' => $date,
-        'user' => $user_data,
-        'activity_duration' => $log->getChangedTime() - $log->getCreatedTime(),
+        'Date' => $date,
+        'Member' => $user_data,
+        'Activity duration' => $log->getChangedTime() - $log->getCreatedTime(),
       ];
 
       $this->moduleHandler->alter(
@@ -490,12 +497,12 @@ class LogArchiver {
               $row = $logs_lvl4;
             }
             else {
-              $row['activity_duration'] += $logs_lvl4['activity_duration'];
+              $row['Activity duration'] += $logs_lvl4['Activity duration'];
             }
           }
           $from = new \DateTime();
-          $to = (clone $from)->add(\DateInterval::createFromDateString("{$row['activity_duration']} seconds"));
-          $row['activity_duration'] = $this->dateFormatter->formatDiff($from->getTimestamp(), $to->getTimestamp());
+          $to = (clone $from)->add(\DateInterval::createFromDateString("{$row['Activity duration']} seconds"));
+          $row['Activity duration'] = $this->dateFormatter->formatDiff($from->getTimestamp(), $to->getTimestamp());
           $this->preparedLogs[$fileName][] = $row;
         }
       }


### PR DESCRIPTION
**Related Issue/Ticket:**

https://openy.atlassian.net/browse/PRODDEV-271

## Steps to test:

- [ ] Log in as an admin to the site
- [ ] Ensure you have the `Administrator` role
- [ ] Enable `Open Y Virtual YMCA Log` module
- [ ] Navigate through the VY, view some videos, live streams, blog posts, virtual meetings
- [ ] Start some videos, scroll them, and let them reach their end
- [ ] Navigate to the logs and ensure the table headers, data, and filters options are looking more human-readable:
![image](https://user-images.githubusercontent.com/5138333/114565199-b82f1000-9c79-11eb-8bf0-abec2107b8c7.png)

- [ ] Export log records and ensure the exported data and columns headers are also human-readable:
![image](https://user-images.githubusercontent.com/5138333/114565853-59b66180-9c7a-11eb-8a6f-19faa0b37454.png)

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [x] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
