### PR TITLE
Fix duplicated function name

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/openy_gc_auth_custom.install
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/openy_gc_auth_custom.install
@@ -13,7 +13,7 @@ use Drupal\user\RoleInterface;
  * Implements hook_install().
  */
 function openy_gc_auth_custom_install() {
-  _update_user_permissions();
+  _openy_gc_auth_custom_update_user_permissions();
 }
 
 /**
@@ -55,13 +55,13 @@ function openy_gc_auth_custom_update_8002() {
     'views.view.virtual_y_users',
   ]);
 
-  _update_user_permissions();
+  _openy_gc_auth_custom_update_user_permissions();
 }
 
 /**
  * Set proper permissions to access the rest endpoints.
  */
-function _update_user_permissions() {
+function _openy_gc_auth_custom_update_user_permissions() {
   $roles = Role::loadMultiple([
     RoleInterface::ANONYMOUS_ID,
     RoleInterface::AUTHENTICATED_ID,

--- a/modules/openy_gc_personal_training/openy_gc_personal_training.install
+++ b/modules/openy_gc_personal_training/openy_gc_personal_training.install
@@ -11,13 +11,6 @@ use Drupal\user\Entity\Role;
  * Implements hook_install().
  */
 function openy_gc_personal_training_install() {
-  _update_user_permissions();
-}
-
-/**
- * Set proper permissions to access the personal_training entities.
- */
-function _update_user_permissions() {
   $roles = Role::loadMultiple([
     'virtual_y',
   ]);


### PR DESCRIPTION
**Related Issue/Ticket:**

`_update_user_permissions` function declared in two modules:  `openy_gc_auth_custom ` and `openy_gc_personal_training`. In case both modules enabled, we will get fatal error.

## Steps to test:

- [ ] No need to test this, I just renamed the function and moved code from function to install because no need in this function in `openy_gc_personal_training`

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [x] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
