### PR TITLE
[PRODDEV-269] Use the tempstore.private instead of the deprecated use…

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Form/VirtualYCustomLoginForm.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_custom/src/Form/VirtualYCustomLoginForm.php
@@ -64,7 +64,7 @@ class VirtualYCustomLoginForm extends FormBase {
   /**
    * Private storage.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $privateTempStore;
 

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique/src/Form/VirtualYReCliqueLoginForm.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique/src/Form/VirtualYReCliqueLoginForm.php
@@ -62,7 +62,7 @@ class VirtualYReCliqueLoginForm extends FormBase {
   /**
    * Private storage.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $privateTempStore;
 

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/openy_gc_auth_reclique_sso.services.yml
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/openy_gc_auth_reclique_sso.services.yml
@@ -1,6 +1,4 @@
 services:
   openy_gc_auth.reclique_sso_client:
     class: Drupal\openy_gc_auth_reclique_sso\SSOClient
-    arguments: [ '@logger.factory', '@config.factory',
-                 '@http_client', '@csrf_token',
-                 '@user.private_tempstore' ]
+    arguments: ['@logger.factory', '@config.factory', '@http_client', '@csrf_token', '@tempstore.private' ]

--- a/modules/openy_gc_auth/modules/openy_gc_auth_yusa/src/Form/VirtualYUSALoginForm.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_yusa/src/Form/VirtualYUSALoginForm.php
@@ -66,7 +66,7 @@ class VirtualYUSALoginForm extends FormBase {
   /**
    * Private storage.
    *
-   * @var \Drupal\Core\TempStore\PrivateTempStoreFactory
+   * @var \Drupal\Core\TempStore\PrivateTempStore
    */
   protected $privateTempStore;
 


### PR DESCRIPTION
…r.private_tempstore for the reCliqueSSO provider, correct var types

**Related Issue/Ticket:**

https://openy.atlassian.net/browse/PRODDEV-269

## Steps to test:

- [ ] Enable the `Reclique SSO OAuth2 Virtual YMCA integration` on the D9 site
- [ ] Check the module was enabled successfully, and there are no errors in the logs
- [ ] Enable and configure Reclique SSO Auth provider for VY
- [ ] Verify the user can log in using Reclique SSO
## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
