### PR TITLE
[PRODDEV-266] Fix menu items migration

### DIFF
--- a/modules/openy_gc_demo/migrations/migrate_plus.migration.virtual_y_menu_link_main.yml
+++ b/modules/openy_gc_demo/migrations/migrate_plus.migration.virtual_y_menu_link_main.yml
@@ -72,8 +72,7 @@ process:
   menu_name: menu_name
   link/uri:
     plugin: link_uri
-    source:
-      - link
+    source: link
   weight: weight
   expanded: expanded
   parent:


### PR DESCRIPTION
**Related Issue/Ticket:**

https://openy.atlassian.net/browse/PRODDEV-266

## Steps to test:

- [ ] Build the site on D9
- [ ] Check there are no errors in the migrations like:

![image](https://user-images.githubusercontent.com/5138333/118634274-04222700-b7db-11eb-845b-f242617b6256.png)

- [ ] Verify the menu links has hashes:

![image](https://user-images.githubusercontent.com/5138333/118634408-29169a00-b7db-11eb-9e07-73166260dec7.png)

- [ ] Click on the nav link having some hash
- [ ] Log in to the site
- [ ] Verify that you've been redirected well after the login

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
