### PR TITLE
[PRODDEV-350] Add cache context for anonymous users if we have x-shared-referer header

### DIFF
--- a/modules/openy_gc_shared_content_server/src/Controller/DownloadsIncrementController.php
+++ b/modules/openy_gc_shared_content_server/src/Controller/DownloadsIncrementController.php
@@ -56,12 +56,12 @@ class DownloadsIncrementController extends ControllerBase {
     $token = $request->get('token');
     $uuid = $request->get('uuid');
     $client_url = $request->get('client_url');
-
-    $id = reset($this->entityTypeManager
+    $ids = $this->entityTypeManager
       ->getStorage('shared_content_source')
       ->getQuery()
       ->condition('url', $client_url)
-      ->execute());
+      ->execute();
+    $id = reset($ids);
 
     if (!empty($id)) {
       $source = SharedContentSource::load($id);
@@ -73,10 +73,10 @@ class DownloadsIncrementController extends ControllerBase {
     if ($source->getToken() !== $token) {
       $status = 'error';
     }
-
-    $node = reset($this->entityTypeManager
+    $nodes = $this->entityTypeManager
       ->getStorage('node')
-      ->loadByProperties(['uuid' => $uuid]));
+      ->loadByProperties(['uuid' => $uuid]);
+    $node = reset($nodes);
 
     if (!($node instanceof NodeInterface)) {
       $status = 'error';


### PR DESCRIPTION
**Related Issue/Ticket:**

https://openy.atlassian.net/browse/PRODDEV-350

This is just proof of the concept of a possible issue. We have some clients that have empty results from the shared content server, looks like this can be fixed by re-creating the shared server entity and cache clear, so I think this is a more caching issue.

During the investigation, I found a possible problem - https://www.drupal.org/project/jsonapi/issues/2962986

> Actually, what it looks like is happening is if I make a request as an anonymous user, the empty response is being cached. Then all requests afterwards, even using authentication methods, come back with the same empty response (until I clear the cache).

In shared content, all requests goes from anonymous users, so request for the un-approved client can be cached and returned for the rest of the clients.

**Proposed fix:** - add cache context with `headers:x-shared-referer` when we have this header (Only in shared content requests)

## Steps to test:

- [ ] Apply this patch on the shared content server and clear cache
- [ ] Check on the client that we have some results in shared content
- [ ] Verify that issue resolved for the rest of the VY clients (based on feedback)

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [x] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
