### PR TITLE
Added redirection check for administrator and site owner roles.

### DIFF
--- a/modules/openy_gc_auth/openy_gc_auth.services.yml
+++ b/modules/openy_gc_auth/openy_gc_auth.services.yml
@@ -14,4 +14,4 @@ services:
 
   openy_gc_auth.user_authorizer:
     class: Drupal\openy_gc_auth\GCUserAuthorizer
-    arguments: ['@entity_type.manager', '@event_dispatcher']
+    arguments: ['@entity_type.manager', '@event_dispatcher', '@messenger']

--- a/modules/openy_gc_auth/src/GCUserAuthorizer.php
+++ b/modules/openy_gc_auth/src/GCUserAuthorizer.php
@@ -76,7 +76,6 @@ class GCUserAuthorizer {
     // Redirecting user login page.
     $userRolesArray = [
       'administrator',
-      'site_owner',
       'virtual_ymca_editor'
     ];
     foreach ($userRolesArray as $role) {

--- a/modules/openy_gc_auth/src/GCUserAuthorizer.php
+++ b/modules/openy_gc_auth/src/GCUserAuthorizer.php
@@ -5,6 +5,7 @@ namespace Drupal\openy_gc_auth;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\openy_gc_auth\Event\GCUserLoginEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 
 /**
  * User Authorizer class.
@@ -73,9 +74,13 @@ class GCUserAuthorizer {
       }
     }
     // Redirecting user login page.
-    $userRolesArray = ['administrator', 'site_owner'];
-    foreach ($userRolesArray as $key => $role) {
-      if($account->hasRole($role)) {
+    $userRolesArray = [
+      'administrator',
+      'site_owner',
+      'virtual_ymca_editor'
+    ];
+    foreach ($userRolesArray as $role) {
+      if ($account->hasRole($role)) {
         $response = new RedirectResponse('/user/login', 301);
         $response->send();
       }

--- a/modules/openy_gc_auth/src/GCUserAuthorizer.php
+++ b/modules/openy_gc_auth/src/GCUserAuthorizer.php
@@ -4,10 +4,11 @@ namespace Drupal\openy_gc_auth;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\openy_gc_auth\Event\GCUserLoginEvent;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\HttpFoundation\RedirectResponse;
 use Drupal\Core\Messenger\MessengerInterface;
 use Drupal\Core\Url;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
 
 /**
  * User Authorizer class.
@@ -44,7 +45,7 @@ class GCUserAuthorizer {
    *   Entity Type Manager.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
    *   Event dispatcher.
-   *  @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
    *   The messenger service.
    */
   public function __construct(EntityTypeManagerInterface $entityTypeManager, EventDispatcherInterface $event_dispatcher, MessengerInterface $messenger) {

--- a/modules/openy_gc_auth/src/GCUserAuthorizer.php
+++ b/modules/openy_gc_auth/src/GCUserAuthorizer.php
@@ -6,8 +6,8 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\openy_gc_auth\Event\GCUserLoginEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Drupal\Core\Url;
 use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Url;
 
 /**
  * User Authorizer class.
@@ -44,6 +44,8 @@ class GCUserAuthorizer {
    *   Entity Type Manager.
    * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
    *   Event dispatcher.
+   *  @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
    */
   public function __construct(EntityTypeManagerInterface $entityTypeManager, EventDispatcherInterface $event_dispatcher, MessengerInterface $messenger) {
     $this->userStorage = $entityTypeManager->getStorage('user');
@@ -92,7 +94,7 @@ class GCUserAuthorizer {
     foreach ($userRolesArray as $role) {
       if ($account->hasRole($role)) {
         $loginUrl = Url::fromRoute('user.login')->toString();
-        $this->messenger->addMessage(t('You have to login as real user, since you are an administrator.'));
+        $this->messenger->addMessage($this->t('You have to login as real user, since you are an administrator.'));
         return new RedirectResponse($loginUrl, 302);
       }
     }

--- a/modules/openy_gc_auth/src/GCUserAuthorizer.php
+++ b/modules/openy_gc_auth/src/GCUserAuthorizer.php
@@ -4,11 +4,10 @@ namespace Drupal\openy_gc_auth;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\openy_gc_auth\Event\GCUserLoginEvent;
-use Drupal\Core\Messenger\MessengerInterface;
-use Drupal\Core\Url;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-
+use Drupal\Core\Url;
+use Drupal\Core\Messenger\MessengerInterface;
 
 /**
  * User Authorizer class.

--- a/modules/openy_gc_auth/src/GCUserAuthorizer.php
+++ b/modules/openy_gc_auth/src/GCUserAuthorizer.php
@@ -73,11 +73,12 @@ class GCUserAuthorizer {
         $account->save();
       }
     }
-    // Redirecting user login page.
+    // List of roles to redirect user login page.
     $userRolesArray = [
       'administrator',
-      'virtual_ymca_editor'
+      'virtual_ymca_editor',
     ];
+    // Redirecting user login page.
     foreach ($userRolesArray as $role) {
       if ($account->hasRole($role)) {
         $response = new RedirectResponse('/user/login', 301);

--- a/modules/openy_gc_auth/src/GCUserAuthorizer.php
+++ b/modules/openy_gc_auth/src/GCUserAuthorizer.php
@@ -72,6 +72,14 @@ class GCUserAuthorizer {
         $account->save();
       }
     }
+    // Redirecting user login page.
+    $userRolesArray = ['administrator', 'site_owner'];
+    foreach ($userRolesArray as $key => $role) {
+      if($account->hasRole($role)) {
+        $response = new RedirectResponse('/user/login', 301);
+        $response->send();
+      }
+    }
     // Instantiate GC login user event.
     $event = new GCUserLoginEvent($account, $extra_data);
     // Dispatch the event.

--- a/modules/openy_gc_auth/src/GCUserAuthorizer.php
+++ b/modules/openy_gc_auth/src/GCUserAuthorizer.php
@@ -3,11 +3,11 @@
 namespace Drupal\openy_gc_auth;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Messenger\MessengerInterface;
+use Drupal\Core\Url;
 use Drupal\openy_gc_auth\Event\GCUserLoginEvent;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Drupal\Core\Url;
-use Drupal\Core\Messenger\MessengerInterface;
 
 /**
  * User Authorizer class.

--- a/modules/openy_gc_auth/src/GCUserAuthorizer.php
+++ b/modules/openy_gc_auth/src/GCUserAuthorizer.php
@@ -89,7 +89,6 @@ class GCUserAuthorizer {
     $event = new GCUserLoginEvent($account, $extra_data);
     // Dispatch the event.
     $this->eventDispatcher->dispatch(GCUserLoginEvent::EVENT_NAME, $event);
-
     user_login_finalize($account);
 
   }


### PR DESCRIPTION
https://github.com/ymcatwincities/openy_gated_content/issues/140


## Steps to test:

- Pull the code from openy-140 branch.
- Locate a staff member (Site Owner and/or Virtual YMCA Editor roles) with an email address registered within Nationwide Membership. Example: bills@northpennymca.org
- Attempt a login with this email address on the Virtual Y Login landing page.
- ![image](https://user-images.githubusercontent.com/6428296/121198128-84462480-c88f-11eb-8e7c-22b2bc503bda.png)
- If the staff user had administrator or site owner roles prior to this login, they should redirect to user/login page.
