### PR TITLE
[PRODDEV-413] Set the event time zone to UTC

### DIFF
--- a/src/Controller/EventsController.php
+++ b/src/Controller/EventsController.php
@@ -185,6 +185,7 @@ class EventsController extends ControllerBase {
     $result = $query->execute()->fetchAll(\PDO::FETCH_ASSOC);
 
     $instances = [];
+    $timezone = new \DateTimeZone('UTC');
     foreach ($result as $item) {
       $instances[] = [
         'type' => 'eventinstance',
@@ -194,8 +195,8 @@ class EventsController extends ControllerBase {
         'title' => $item['field_ls_title_value'] ?: $item['title'],
         'host_name' => $item['field_ls_host_name_value'] ?: $item['esh_field_ls_host_name_value'],
         'date' => [
-          'value' => (new DrupalDateTime($item['date__value']))->format('c'),
-          'end_value' => (new DrupalDateTime($item['date__end_value']))->format('c'),
+          'value' => (new DrupalDateTime($item['date__value'], $timezone))->format('c'),
+          'end_value' => (new DrupalDateTime($item['date__end_value'], $timezone))->format('c'),
         ],
       ];
     }


### PR DESCRIPTION
**Related Issue/Ticket:**
[PRODDEV-413](https://openy.atlassian.net/browse/PRODDEV-413?atlOrigin=eyJpIjoiZGMyZmYzNTBhNTI4NDgyYWIyNGE4NDc2ZGFkMDRjMjIiLCJwIjoiamlyYS1zbGFjay1pbnQifQ)

**PLEASE CHECK BASE BRANCH FOR YOUR PR**
**ONLY urgent and approved fixes for point release should go to master branch**

(Replace this line with a link to the related GitHub issue on [ymcatwincities/openy_gated_content](https://github.com/ymcatwincities/openy_gated_content/issues) or your own ticketing system)

## Steps to test:

- [ ] Test with a site whose time zone is NOT UTC
- [ ] Find an event on virtual-ymca#/schedule and observe the time
- [ ] Click through the detail page and observe the time on the detail page matches the schedule.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [x] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
