### PR TITLE
Fix for empty content title issue on exported csv logs.

### DIFF
--- a/modules/openy_gc_log/src/LogArchiver.php
+++ b/modules/openy_gc_log/src/LogArchiver.php
@@ -423,7 +423,7 @@ class LogArchiver {
             $metadata = unserialize($log->get('event_metadata')->value, ['allowed_classes' => FALSE]);
           }
           foreach ([
-            'entity_title' => $this->t('Content title'),
+            'entity_title' => 'Content title',
             'entity_instructor_name' => 'Instructor name',
             'entity_created' => 'Content creation date',
           ] as $key => $export_col) {


### PR DESCRIPTION
Fix for [Issue#152](https://github.com/ymcatwincities/openy_gated_content/issues/152)

## Steps to test:
- Login into VY site as admin or user which has access to VY logs and archives
- From the admin menu, go to Virtual Y --> Logs --> Export log records.
- Click on "Create an export file" button in the page.
- Next from admin menu go to, Virtual Y --> Logs --> Log Archives
- Download and extract latest vy log archive file.
- Open the csv file and content titles are now being displayed.
