### PR TITLE
[PRODDEV-439] Add hook_update to update existed data and add duration reference

### DIFF
--- a/modules/openy_gc_storage/openy_gc_storage.install
+++ b/modules/openy_gc_storage/openy_gc_storage.install
@@ -310,27 +310,27 @@ function openy_gc_storage_update_8016() {
 /**
  * Update/create configs related to Duration reference field.
  */
-//function openy_gc_storage_update_8017() {
-//  $config_dir = drupal_get_path('module', 'openy_gc_storage');
-//  $config_dir .= '/config/install/';
-//  // Update configuration.
-//  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
-//  $config_importer->setDirectory($config_dir);
-//  $config_importer->importConfigs([
-//    'taxonomy.vocabulary.gc_duration',
-//    'language.content_settings.taxonomy_term.gc_duration',
-//    'field.storage.taxonomy_term.field_gc_duration_max',
-//    'field.storage.taxonomy_term.field_gc_duration_min',
-//    'field.storage.taxonomy_term.field_gc_duration_media',
-//    'field.storage.node.field_gc_duration_reference',
-//    'field.field.taxonomy_term.gc_duration.field_gc_duration_max',
-//    'field.field.taxonomy_term.gc_duration.field_gc_duration_min',
-//    'field.field.taxonomy_term.gc_duration.field_gc_duration_media',
-//    'field.field.node.gc_video.field_gc_duration_reference',
-//    'core.entity_form_display.taxonomy_term.gc_duration.default',
-//    'core.entity_form_display.node.gc_video.default',
-//    'core.entity_view_display.taxonomy_term.gc_duration.default',
-//    'core.entity_view_display.node.gc_video.default',
-//    'core.entity_view_display.node.gc_video.teaser',
-//  ]);
-//}
+function openy_gc_storage_update_8017() {
+  $config_dir = drupal_get_path('module', 'openy_gc_storage');
+  $config_dir .= '/config/install/';
+  // Update configuration.
+  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+  $config_importer->setDirectory($config_dir);
+  $config_importer->importConfigs([
+    'taxonomy.vocabulary.gc_duration',
+    'language.content_settings.taxonomy_term.gc_duration',
+    'field.storage.taxonomy_term.field_gc_duration_max',
+    'field.storage.taxonomy_term.field_gc_duration_min',
+    'field.storage.taxonomy_term.field_gc_duration_media',
+    'field.storage.node.field_gc_duration_reference',
+    'field.field.taxonomy_term.gc_duration.field_gc_duration_max',
+    'field.field.taxonomy_term.gc_duration.field_gc_duration_min',
+    'field.field.taxonomy_term.gc_duration.field_gc_duration_media',
+    'field.field.node.gc_video.field_gc_duration_reference',
+    'core.entity_form_display.taxonomy_term.gc_duration.default',
+    'core.entity_form_display.node.gc_video.default',
+    'core.entity_view_display.taxonomy_term.gc_duration.default',
+    'core.entity_view_display.node.gc_video.default',
+    'core.entity_view_display.node.gc_video.teaser',
+  ]);
+}

--- a/modules/openy_gc_storage/openy_gc_storage.install
+++ b/modules/openy_gc_storage/openy_gc_storage.install
@@ -310,27 +310,27 @@ function openy_gc_storage_update_8016() {
 /**
  * Update/create configs related to Duration reference field.
  */
-function openy_gc_storage_update_8017() {
-  $config_dir = drupal_get_path('module', 'openy_gc_storage');
-  $config_dir .= '/config/install/';
-  // Update configuration.
-  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
-  $config_importer->setDirectory($config_dir);
-  $config_importer->importConfigs([
-    'taxonomy.vocabulary.gc_duration',
-    'language.content_settings.taxonomy_term.gc_duration',
-    'field.storage.taxonomy_term.field_gc_duration_max',
-    'field.storage.taxonomy_term.field_gc_duration_min',
-    'field.storage.taxonomy_term.field_gc_duration_media',
-    'field.storage.node.field_gc_duration_reference',
-    'field.field.taxonomy_term.gc_duration.field_gc_duration_max',
-    'field.field.taxonomy_term.gc_duration.field_gc_duration_min',
-    'field.field.taxonomy_term.gc_duration.field_gc_duration_media',
-    'field.field.node.gc_video.field_gc_duration_reference',
-    'core.entity_form_display.taxonomy_term.gc_duration.default',
-    'core.entity_form_display.node.gc_video.default',
-    'core.entity_view_display.taxonomy_term.gc_duration.default',
-    'core.entity_view_display.node.gc_video.default',
-    'core.entity_view_display.node.gc_video.teaser',
-  ]);
-}
+//function openy_gc_storage_update_8017() {
+//  $config_dir = drupal_get_path('module', 'openy_gc_storage');
+//  $config_dir .= '/config/install/';
+//  // Update configuration.
+//  $config_importer = \Drupal::service('openy_upgrade_tool.importer');
+//  $config_importer->setDirectory($config_dir);
+//  $config_importer->importConfigs([
+//    'taxonomy.vocabulary.gc_duration',
+//    'language.content_settings.taxonomy_term.gc_duration',
+//    'field.storage.taxonomy_term.field_gc_duration_max',
+//    'field.storage.taxonomy_term.field_gc_duration_min',
+//    'field.storage.taxonomy_term.field_gc_duration_media',
+//    'field.storage.node.field_gc_duration_reference',
+//    'field.field.taxonomy_term.gc_duration.field_gc_duration_max',
+//    'field.field.taxonomy_term.gc_duration.field_gc_duration_min',
+//    'field.field.taxonomy_term.gc_duration.field_gc_duration_media',
+//    'field.field.node.gc_video.field_gc_duration_reference',
+//    'core.entity_form_display.taxonomy_term.gc_duration.default',
+//    'core.entity_form_display.node.gc_video.default',
+//    'core.entity_view_display.taxonomy_term.gc_duration.default',
+//    'core.entity_view_display.node.gc_video.default',
+//    'core.entity_view_display.node.gc_video.teaser',
+//  ]);
+//}

--- a/modules/openy_gc_storage/openy_gc_storage.post_update.php
+++ b/modules/openy_gc_storage/openy_gc_storage.post_update.php
@@ -173,7 +173,14 @@ function _openy_gc_storage_build_duration_references(&$sandbox) {
     // By default we'll set reference to 'Undefined' duration term.
     $sandbox['sandbox']['default_duation_term'] = '';
 
-    $duration_terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties(['vid' => 'gc_duration']);
+    // Collect all duration terms, sorted by minimum duration value.
+    $taxonomy_storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+    $query = $taxonomy_storage->getQuery();
+    $query->condition('vid', 'gc_duration')
+      ->sort('field_gc_duration_min', 'ASC');
+    $duration_terms_ids = $query->execute();
+
+    $duration_terms = $taxonomy_storage->loadMultiple($duration_terms_ids);
     /**
      * @var int $duration_id
      * @var \Drupal\taxonomy\TermInterface $duration_term

--- a/modules/openy_gc_storage/openy_gc_storage.post_update.php
+++ b/modules/openy_gc_storage/openy_gc_storage.post_update.php
@@ -129,7 +129,12 @@ function openy_gc_storage_post_update_create_durations(&$sandbox) {
     [
       'title' => '90 minutes',
       'low' => 3900,
-      'high' => 5700,
+      'high' => 5699,
+    ],
+    [
+      'title' => '90 minutes or more',
+      'low' => 5700,
+      'high' => 0,
     ],
     [
       'title' => 'Undefined',
@@ -206,12 +211,17 @@ function _openy_gc_storage_build_duration_references(&$sandbox) {
     // Let's find id of the duration term that has minimal value less than the
     // duration of the given video & has maximum value bigger than or equal to
     // the duration of the given video.
+    // If term has '0' as a maximum range, then we assign it to the given node
+    // provided the minimum range is satisfiable.
     if (!$duration_field->isEmpty()) {
       $duration_value = $duration_field->getString();
       foreach ($sandbox['sandbox']['durations'] as $duration_id => $duration_range) {
         if (
           $duration_range['min'] < $duration_value
-          && $duration_range['max'] >= $duration_value
+          && (
+            $duration_range['max'] === '0'
+            || $duration_range['max'] >= $duration_value
+          )
         ) {
           $duration_term_tid = $duration_id;
           break;

--- a/modules/openy_gc_storage/openy_gc_storage.post_update.php
+++ b/modules/openy_gc_storage/openy_gc_storage.post_update.php
@@ -95,76 +95,64 @@ function openy_gc_storage_post_update_migrate_eventinstance_instructors(&$sandbo
  * Create terms for Virtual Y Duration.
  */
 function openy_gc_storage_post_update_create_durations(&$sandbox) {
-  if (!isset($sandbox['durations'])) {
-    $sandbox['durations'] = [
-      [
-        'title' => '10 minutes or less',
-        'low' => 1,
-        'high' => 659,
-      ],
-      [
-        'title' => '15 minutes',
-        'low' => 660,
-        'high' => 1080,
-      ],
-      [
-        'title' => '20 minutes',
-        'low' => 1081,
-        'high' => 1319,
-      ],
-      [
-        'title' => '30 minutes',
-        'low' => 1320,
-        'high' => 1919,
-      ],
-      [
-        'title' => '45 minutes',
-        'low' => 1920,
-        'high' => 2819,
-      ],
-      [
-        'title' => '60 minutes',
-        'low' => 2820,
-        'high' => 3899,
-      ],
-      [
-        'title' => '90 minutes',
-        'low' => 3900,
-        'high' => 5700,
-      ],
-      [
-        'title' => 'Undefined',
-        'low' => 0,
-        'high' => 0,
-      ],
-    ];
-
-    $sandbox['processed'] = 0;
-    $sandbox['max'] = count($sandbox['durations']);
-  }
+  $durations = [
+    [
+      'title' => '10 minutes or less',
+      'low' => 1,
+      'high' => 659,
+    ],
+    [
+      'title' => '15 minutes',
+      'low' => 660,
+      'high' => 1080,
+    ],
+    [
+      'title' => '20 minutes',
+      'low' => 1081,
+      'high' => 1319,
+    ],
+    [
+      'title' => '30 minutes',
+      'low' => 1320,
+      'high' => 1919,
+    ],
+    [
+      'title' => '45 minutes',
+      'low' => 1920,
+      'high' => 2819,
+    ],
+    [
+      'title' => '60 minutes',
+      'low' => 2820,
+      'high' => 3899,
+    ],
+    [
+      'title' => '90 minutes',
+      'low' => 3900,
+      'high' => 5700,
+    ],
+    [
+      'title' => 'Undefined',
+      'low' => 0,
+      'high' => 0,
+    ],
+  ];
 
   $term_storage = \Drupal::entityTypeManager()
     ->getStorage('taxonomy_term');
 
-  // Process 5 durations per run.
-  for ($i = 0; $i < 5; $i++) {
-    if (!empty($sandbox['durations'])) {
-      $duration = array_shift($sandbox['durations']);
-      $term = $term_storage->create([
-        'vid'                   => 'gc_duration',
-        'name'                  => $duration['title'],
-        'field_gc_duration_min' => $duration['low'],
-        'field_gc_duration_max' => $duration['high'],
-      ]);
-      $term->save();
-      $sandbox['processed']++;
-    }
+  foreach ($durations as $duration) {
+    $term = $term_storage->create([
+      'vid'                   => 'gc_duration',
+      'name'                  => $duration['title'],
+      'field_gc_duration_min' => $duration['low'],
+      'field_gc_duration_max' => $duration['high'],
+    ]);
+    $term->save();
   }
 
-  $sandbox['#finished'] = empty($sandbox['durations']) ? TRUE : $sandbox['processed'] / $sandbox['max'];
-  if ($sandbox['#finished'] === TRUE) {
-    return t('The Duration terms have been created.');
-  }
+  $sandbox['#finished'] = 1;
+  return t('The Duration terms have been created.');
 }
 
 /**

--- a/modules/openy_gc_storage/openy_gc_storage.post_update.php
+++ b/modules/openy_gc_storage/openy_gc_storage.post_update.php
@@ -90,3 +90,165 @@ function openy_gc_storage_post_update_migrate_eventseries_instructors(&$sandbox)
 function openy_gc_storage_post_update_migrate_eventinstance_instructors(&$sandbox) {
   _openy_gc_storage_migrate_instructors($sandbox, 'eventinstance', 'field_ls_host_name');
 }
+
+/**
+ * Create terms for Virtual Y Duration.
+ */
+function openy_gc_storage_post_update_create_durations(&$sandbox) {
+  if (!isset($sandbox['durations'])) {
+    $sandbox['durations'] = [
+      [
+        'title' => '10 minutes or less',
+        'low' => 1,
+        'high' => 659,
+      ],
+      [
+        'title' => '15 minutes',
+        'low' => 660,
+        'high' => 1080,
+      ],
+      [
+        'title' => '20 minutes',
+        'low' => 1081,
+        'high' => 1319,
+      ],
+      [
+        'title' => '30 minutes',
+        'low' => 1320,
+        'high' => 1919,
+      ],
+      [
+        'title' => '45 minutes',
+        'low' => 1920,
+        'high' => 2819,
+      ],
+      [
+        'title' => '60 minutes',
+        'low' => 2820,
+        'high' => 3899,
+      ],
+      [
+        'title' => '90 minutes',
+        'low' => 3900,
+        'high' => 5700,
+      ],
+      [
+        'title' => 'Undefined',
+        'low' => 0,
+        'high' => 0,
+      ],
+    ];
+
+    $sandbox['processed'] = 0;
+    $sandbox['max'] = count($sandbox['durations']);
+  }
+
+  $term_storage = \Drupal::entityTypeManager()
+    ->getStorage('taxonomy_term');
+
+  // Process 5 durations per run.
+  for ($i = 0; $i < 5; $i++) {
+    if (!empty($sandbox['durations'])) {
+      $duration = array_shift($sandbox['durations']);
+      $term = $term_storage->create([
+        'vid'                   => 'gc_duration',
+        'name'                  => $duration['title'],
+        'field_gc_duration_min' => $duration['low'],
+        'field_gc_duration_max' => $duration['high'],
+      ]);
+      $term->save();
+      $sandbox['processed']++;
+    }
+  }
+
+  $sandbox['#finished'] = empty($sandbox['durations']) ? TRUE : $sandbox['processed'] / $sandbox['max'];
+  if ($sandbox['#finished'] === TRUE) {
+    return t('The Duration terms have been created.');
+  }
+}
+
+/**
+ * Helper method to build duration references based on duration field value.
+ */
+function _openy_gc_storage_build_duration_references(&$sandbox) {
+  if (!isset($sandbox['sandbox']['ids'])) {
+    $sandbox['sandbox']['ids'] = \Drupal::entityQuery('node')
+      ->condition('type', 'gc_video')
+      ->sort('nid')
+      ->execute();
+
+    // By default we'll set reference to 'Undefined' duration term.
+    $sandbox['sandbox']['default_duration_term'] = \Drupal::entityQuery('taxonomy_term')
+      ->condition('vid', 'gc_duration')
+      ->condition('field_gc_duration_min', 0)
+      ->condition('field_gc_duration_max', 0)
+      ->range(0, 1)
+      ->execute();
+    if (!empty($sandbox['sandbox']['default_duration_term'])) {
+      $sandbox['sandbox']['default_duration_term'] = reset($sandbox['sandbox']['default_duration_term']);
+    }
+    else {
+      $sandbox['sandbox']['default_duration_term'] = '';
+    }
+
+    $sandbox['sandbox']['max'] = count($sandbox['sandbox']['ids']);
+    $sandbox['sandbox']['processed'] = 0;
+  }
+
+  $node_storage = \Drupal::entityTypeManager()->getStorage('node');
+
+  for ($i = 0; $i < 5; $i++) {
+    if (empty($sandbox['sandbox']['ids'])) {
+      break;
+    }
+    $duration_term_tid = $sandbox['sandbox']['default_duration_term'];
+
+    $current_nid = array_shift($sandbox['sandbox']['ids']);
+    $node = $node_storage->load($current_nid);
+    /** @var \Drupal\node\NodeInterface $node */
+    $duration_field = $node->get('field_gc_video_duration');
+    // Let's find id of the duration term that has minimal value less than the
+    // duration of the given video & has maximum value bigger than or equal to
+    // the duration of the given video.
+    if (!$duration_field->isEmpty()) {
+      $duration_value = $duration_field->getString();
+      $duration_term = \Drupal::entityQuery('taxonomy_term')
+        ->condition('vid', 'gc_duration')
+        ->condition('field_gc_duration_min', $duration_value, '<')
+        ->condition('field_gc_duration_max', $duration_value, '>=')
+        ->accessCheck(FALSE)
+        // Let's select only first taxonomy that fits the criteria.
+        ->range(0, 1)
+        ->sort('tid')
+        ->execute();
+      if (!empty($duration_term)) {
+        $duration_term_tid = reset($duration_term);
+      }
+    }
+
+    if (!empty($duration_term_tid)) {
+      $node->set('field_gc_duration_reference', $duration_term_tid)->save();
+    }
+
+    $sandbox['sandbox']['processed']++;
+    $sandbox['results']['processed'] = $sandbox['sandbox']['processed'];
+  }
+
+  $sandbox['#finished'] = empty($sandbox['sandbox']['ids']) ? 1 : $sandbox['sandbox']['processed'] / $sandbox['sandbox']['max'];
+
+  $sandbox['finished'] = $sandbox['#finished'];
+  $sandbox['message'] = t(
+    'Processed @current videos out of total @total',
+    [
+      '@current' => $sandbox['sandbox']['processed'],
+      '@total' => $sandbox['sandbox']['max'],
+    ]
+  );
+}
+
+/**
+ * Add appropriate duration references to all existing 'Virtual Y Video' nodes.
+ */
+function openy_gc_storage_post_update_migrate_node_durations(&$sandbox) {
+  _openy_gc_storage_build_duration_references($sandbox);
+}

--- a/openy_gated_content.links.menu.yml
+++ b/openy_gated_content.links.menu.yml
@@ -104,6 +104,13 @@ openy_gated_content.duration:
   parent: openy_gated_content.taxonomy
   weight: 2
 
+openy_gated_content.duration.rebuild:
+  title: 'Rebuild Durations'
+  route_name: openy_gated_content.duration.rebuild
+  description: 'Perform rebuild of the durations references'
+  parent: openy_gated_content.duration
+  weight: 1
+
 openy_gated_content.instructor:
   title: 'Instructors'
   route_name: entity.taxonomy_vocabulary.overview_form

--- a/openy_gated_content.module
+++ b/openy_gated_content.module
@@ -294,6 +294,13 @@ function openy_gated_content_form_taxonomy_term_gc_category_form_alter(&$form, F
 /**
  * Implements hook_form_FORM_ID_alter().
  */
+function openy_gated_content_form_taxonomy_term_gc_duration_form_alter(&$form, FormStateInterface $form_state) {
+  $form['#validate'][] = 'openy_gated_content_taxonomy_term_gc_duration_validation';
+}
+
+/**
+ * Implements hook_form_FORM_ID_alter().
+ */
 function openy_gated_content_form_taxonomy_overview_terms_alter(&$form, FormStateInterface $form_state) {
   $build_info = $form_state->getBuildInfo();
   if (isset($build_info['args'][0]) && $build_info['args'][0] instanceof Vocabulary) {
@@ -365,6 +372,55 @@ function openy_gated_content_taxonomy_term_gc_category_validation(array &$form, 
       $form_state->setErrorByName('parent', "You are not allowed to have more than 2 levels of Categories terms. Please, adjust current term parent accordingly.");
       break;
     }
+  }
+}
+
+/**
+ * Do not allow duration ranges overlapping.
+ */
+function openy_gated_content_taxonomy_term_gc_duration_validation(array &$form, FormStateInterface $form_state) {
+  $taxonomy_storage = \Drupal::entityTypeManager()->getStorage('taxonomy_term');
+  $entity_id = 0;
+
+  /** @var EntityInterface $entity */
+  $entity = $form_state->getFormObject()->getEntity();
+  if (!$entity->isNew()) {
+    $entity_id = $entity->id();
+  }
+
+  // We have to make sure there are no overlapping duration terms. In order to
+  // do that, let's request all of the duration terms that satisfy the following
+  // criteria: "start-1" <= "end-2" && "start-2" <= "end-1".
+  // "start-1"
+  $min = $form_state->getValue('field_gc_duration_min', [['value' => '']]);
+  // "end-1"
+  $max = $form_state->getValue('field_gc_duration_max', [['value' => '']]);
+
+  $query = $taxonomy_storage->getQuery()
+    ->condition('vid', 'gc_duration')
+    ->range(0, 1)
+    // "start-2"
+    ->condition('field_gc_duration_min', $max[0]['value'], '<=')
+    // "end-2"
+    ->condition('field_gc_duration_max', $min[0]['value'], '>=');
+
+  // Exclude current duration term.
+  if ($entity_id !== 0) {
+    $query->condition('tid', $entity_id, '<>');
+  }
+
+  $intersection_term_id = $query->execute();
+
+  if (!empty($intersection_term_id)) {
+    $intersection_term_id = reset($intersection_term_id);
+    $intersection_term = $taxonomy_storage->load($intersection_term_id);
+
+    $form_state->setErrorByName('field_gc_duration_min', t(
+      'Given range intersects with the range of the Duration term @link. Please, make sure the newly created Duration range does not overlap existing duration ranges.',
+      [
+        '@link' => $intersection_term->toLink(NULL, 'edit-form')->toString(),
+      ]
+    ));
   }
 }
 

--- a/openy_gated_content.routing.yml
+++ b/openy_gated_content.routing.yml
@@ -72,3 +72,11 @@ openy_gated_content.favorites.delete:
   requirements:
     _permission: 'access content'
     _role: 'authenticated'
+
+openy_gated_content.duration.rebuild:
+  path: '/admin/virtual-y/rebuild-durations'
+  defaults:
+    _form: '\Drupal\openy_gated_content\Form\RebuildDurationsForm'
+    _title: 'Rebuild Duration references'
+  requirements:
+    _permission: 'edit any gc_video content'

--- a/src/Form/RebuildDurationsForm.php
+++ b/src/Form/RebuildDurationsForm.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Drupal\openy_gated_content\Form;
+
+use Drupal\Core\Batch\BatchBuilder;
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+
+/**
+ * Rebuild Durations Form class.
+ */
+class RebuildDurationsForm extends ConfirmFormBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'virtual_y_rebuild_durations';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    return $this->t('<em>Duration reference</em> field of every <em>Virtual Y Video</em> node is going to be populated based on the value of <em>Duration</em> field. If <em>Duration</em> field is empty, default Duration term will be used.');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return Url::fromRoute('entity.taxonomy_vocabulary.overview_form', ['taxonomy_vocabulary' => 'gc_duration']);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->t('Are you sure you want to rebuild all the references to <em>Duration</em> taxonomies within every <em>Virtual Y Video</em> node?');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $batch_builder = new BatchBuilder();
+    $batch_builder
+      ->setFile(drupal_get_path('module', 'openy_gc_storage') . '/openy_gc_storage.post_update.php')
+      ->addOperation('_openy_gc_storage_build_duration_references')
+      ->setFinishCallback([$this, 'finished']);
+
+    batch_set($batch_builder->toArray());
+  }
+
+  /**
+   * Finished callback for batch.
+   */
+  public function finished($success, $results, $operations) {
+    $message = $this->t('Number of video nodes affected by batch: @count', [
+      '@count' => $results['processed'],
+    ]);
+
+    $this->messenger()->addStatus($message);
+
+    return new RedirectResponse($this->getCancelUrl()->toString());
+  }
+
+}


### PR DESCRIPTION
**Related Issue/Ticket:**

[PRODDEV-439](https://openy.atlassian.net/browse/PRODDEV-439)

## Steps to test:

- [ ] Make sure **Rebuild Durations** link is available under Virtual Y -> Taxonomy -> Duration menu links.
- [ ] Make sure the Videos are assigned appropriate Duration term reference.
- [ ] Make sure the Videos are assigned "Unassigned" duration taxonomy term when "Duration" value for video is empty or does not correspond to the range of any existing Duration term. 

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [x] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
