### PR TITLE
[PRODDEV-450] Fix the error on a fields definitions' update

### DIFF
--- a/openy_gated_content.install
+++ b/openy_gated_content.install
@@ -347,8 +347,8 @@ function openy_gated_content_update_8018() {
   $entity_type->setClass(VyFavoriteItem::class);
   $definitions = VyFavoriteItem::baseFieldDefinitions($entity_type);
   foreach ($definitions as $name => $definition) {
-    if ($definition_manager->getFieldStorageDefinition($name, $entity_type_id)) {
-      $definition_manager->updateFieldStorageDefinition($definition);
+    if ($original = $definition_manager->getFieldStorageDefinition($name, $entity_type_id)) {
+      $definition_manager->updateFieldStorageDefinition($original);
     }
     else {
       $definition_manager->installFieldStorageDefinition($name, $entity_type_id, 'openy_gated_content', $definition);


### PR DESCRIPTION
**Related Issue/Ticket:**

https://github.com/ymcatwincities/openy_gated_content/issues/157
https://openy.atlassian.net/browse/PRODDEV-450

## Steps to test:

- [ ] Install VY 1.5.0
- [ ] Update to the latest version and apply the patch
- [ ] Run database updates
- [ ] Observe that `openy_gated_content_update_8018` finished successfully
- [ ] Finally observe the issue is resolved.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
