### PR TITLE
[PRODDEV-365] ReClique SSO and others improvements

### DIFF
--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/README.md
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/README.md
@@ -13,3 +13,12 @@ at the Virtual YMCA settings: /admin/openy/openy-gc-auth/settings
 ## I need help.
 In case, if you need help, please write your question
 at the #developers channel at Open Y slack.
+
+## Notice about the email change
+If the email was changed on the Reclique SSO provider side, the user should
+be logged in with a new email after the change. No additional actions should
+be needed from the Drupal site admin side.
+When the issue was taken by QA -- it was not possible to check this scenario
+since there were no ability to change the email by user himself on the
+Reclique SSO provider site. So for the moment this feature is marked as
+"untested".

--- a/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/src/SSOClient.php
+++ b/modules/openy_gc_auth/modules/openy_gc_auth_reclique_sso/src/SSOClient.php
@@ -165,7 +165,7 @@ class SSOClient {
    *   Returns TRUE if user has active subscription.
    */
   public function validateUserSubscription($userData) {
-    return $userData->member->Status === 'Active';
+    return ($userData->member instanceof \stdClass) && $userData->member->Status === 'Active';
   }
 
   /**

--- a/modules/openy_gc_auth/src/GCUserAuthorizer.php
+++ b/modules/openy_gc_auth/src/GCUserAuthorizer.php
@@ -51,6 +51,13 @@ class GCUserAuthorizer {
 
     // Create drupal user if it doesn't exist and login it.
     $account = user_load_by_mail($email);
+
+    if (!$account) {
+      $account = user_load_by_name($name);
+      $account->setEmail($email);
+      $account->save();
+    }
+
     if (!$account) {
       $user = $this->userStorage->create();
       $user->setPassword(user_password());

--- a/modules/openy_gc_auth/src/GCUserAuthorizer.php
+++ b/modules/openy_gc_auth/src/GCUserAuthorizer.php
@@ -44,20 +44,18 @@ class GCUserAuthorizer {
    * {@inheritdoc}
    */
   public function authorizeUser($name, $email, array $extra_data = []) {
-
     if (empty($name) || empty($email)) {
       return;
     }
 
-    // Create drupal user if it doesn't exist and login it.
+    // Try to find the user by an email, if not -- then re-search by name.
     $account = user_load_by_mail($email);
-
-    if (!$account) {
-      $account = user_load_by_name($name);
+    if (!$account && ($account = user_load_by_name($name))) {
       $account->setEmail($email);
       $account->save();
     }
 
+    // Create drupal user if it doesn't exist and login it.
     if (!$account) {
       $user = $this->userStorage->create();
       $user->setPassword(user_password());
@@ -85,7 +83,6 @@ class GCUserAuthorizer {
     $this->eventDispatcher->dispatch(GCUserLoginEvent::EVENT_NAME, $event);
 
     user_login_finalize($account);
-
   }
 
   /**


### PR DESCRIPTION
**Related Issue/Ticket:**

https://openy.atlassian.net/browse/PRODDEV-365

## Steps to test:

- [ ] Enable ReClique SSO auth provider module
- [ ] Enable the ReClique SSO in VY auth settings
- [ ] Try to log in to the VY as a user which has no membership activated, etc. (I've created the new account on the ReClique to reproduce this)
- [ ] Verify that there is no Drupal error popup
- [ ] Log in to the VY using the ReClique active user
- [ ] Find the way to change the user's email on the ReClique and verify the user can log in to the VY

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
