### PR TITLE
[PRODDEV-451] Add custom fields' definitions to the bundles map

### DIFF
--- a/modules/openy_gc_shared_content/openy_gc_shared_content.install
+++ b/modules/openy_gc_shared_content/openy_gc_shared_content.install
@@ -58,4 +58,53 @@ function openy_gc_shared_content_install() {
     'views.view.event_series',
     'views.view.events',
   ]);
+
+  _openy_gc_shared_content_add_definitions_to_bundle_map();
+}
+
+/**
+ * Add definitions to the bundles map.
+ */
+function openy_gc_shared_content_update_8001() {
+  _openy_gc_shared_content_add_definitions_to_bundle_map();
+}
+
+/**
+ * Add field_gc_origin and field_gc_origin info to the bundles map.
+ */
+function _openy_gc_shared_content_add_definitions_to_bundle_map() {
+  $field_names = [
+    'field_gc_share',
+    'field_gc_origin',
+  ];
+  $entity_type_ids = [
+    'node',
+    'eventseries',
+    'eventinstance',
+  ];
+  $shared_content_manager = \Drupal::service('plugin.manager.shared_content_source_type');
+  foreach ($shared_content_manager->getDefinitions() as $plugin_id => $plugin) {
+    $instance = $shared_content_manager->createInstance($plugin_id);
+    $plugins_info[$instance->getEntityType()][] = $instance->getEntityBundle();
+  }
+  $persistent_map = \Drupal::keyValue('entity.definitions.bundle_field_map');
+  $map = $persistent_map->getAll();
+  $entity_field_manager = \Drupal::service('entity_field.manager');
+  foreach ($entity_type_ids as $entity_type_id) {
+    if (!isset($plugins_info[$entity_type_id])) {
+      continue;
+    }
+    $managed_bundles = $plugins_info[$entity_type_id];
+    foreach ($managed_bundles as $bundle) {
+      $field_definitions = $entity_field_manager->getFieldDefinitions($entity_type_id, $bundle);
+      foreach ($field_names as $field_name) {
+        $map[$entity_type_id][$field_name]['type'] = $field_definitions[$field_name]->getType();
+        $map[$entity_type_id][$field_name]['bundles'][$bundle] = $bundle;
+      }
+    }
+  }
+  // Delete former incorrect map.
+  $persistent_map->deleteAll();
+  // Add a recent map.
+  $persistent_map->setMultiple($map);
 }

--- a/modules/openy_gc_shared_content/openy_gc_shared_content.module
+++ b/modules/openy_gc_shared_content/openy_gc_shared_content.module
@@ -89,17 +89,26 @@ function openy_gc_shared_content_entity_bundle_field_info(EntityTypeInterface $e
     $plugins_info[$instance->getEntityType()][] = $instance->getEntityBundle();
   }
 
-  if (!isset($plugins_info[$entity_type->id()])) {
+  $entity_type_id = $entity_type->id();
+  if (!isset($plugins_info[$entity_type_id])) {
     return [];
   }
-  $managed_bundles = $plugins_info[$entity_type->id()];
+  $managed_bundles = $plugins_info[$entity_type_id];
   if (!in_array($bundle, $managed_bundles)) {
     return [];
   }
   $fields = [];
+  $persistent_map = \Drupal::keyValue('entity.definitions.bundle_field_map');
+  $map = $persistent_map->getAll();
   foreach (openy_gc_shared_content_entity_field_storage_info($entity_type) as $name => $definition) {
     $fields[$name] = $definition;
+    $map[$entity_type_id][$name]['type'] = $definition->getType();
+    $map[$entity_type_id][$name]['bundles'][$bundle] = $bundle;
   }
+  // Delete former incorrect map.
+  $persistent_map->deleteAll();
+  // Add a recent map.
+  $persistent_map->setMultiple($map);
   return $fields;
 }
 

--- a/openy_gated_content.install
+++ b/openy_gated_content.install
@@ -402,3 +402,37 @@ function openy_gated_content_update_8019() {
     }
   }
 }
+
+/**
+ * Add field_vy_permission info to the bundles map.
+ */
+function openy_gated_content_update_8020() {
+  $gc_config = \Drupal::config('openy_gated_content.settings')->getRawData();
+  if (!empty($gc_config['permissions_entities'])) {
+    $permissions_entities = $gc_config['permissions_entities'];
+  }
+  $field_name = 'field_vy_permission';
+  $entity_type_ids = [
+    'node',
+    'eventseries',
+    'eventinstance',
+  ];
+  $persistent_map = \Drupal::keyValue('entity.definitions.bundle_field_map');
+  $map = $persistent_map->getAll();
+  $entity_field_manager = \Drupal::service('entity_field.manager');
+  foreach ($entity_type_ids as $entity_type_id) {
+    if (!isset($permissions_entities[$entity_type_id])) {
+      continue;
+    }
+    $managed_bundles = $permissions_entities[$entity_type_id];
+    foreach ($managed_bundles as $bundle) {
+      $field_definitions = $entity_field_manager->getFieldDefinitions($entity_type_id, $bundle);
+      $map[$entity_type_id][$field_name]['type'] = $field_definitions[$field_name]->getType();
+      $map[$entity_type_id][$field_name]['bundles'][$bundle] = $bundle;
+    }
+  }
+  // Delete former incorrect map.
+  $persistent_map->deleteAll();
+  // Add a recent map.
+  $persistent_map->setMultiple($map);
+}

--- a/openy_gated_content.module
+++ b/openy_gated_content.module
@@ -427,17 +427,26 @@ function openy_gated_content_entity_bundle_field_info(EntityTypeInterface $entit
   if (!empty($gc_config['permissions_entities'])) {
     $permissions_entities = $gc_config['permissions_entities'];
   }
-  if (!isset($permissions_entities[$entity_type->id()])) {
+  $entity_type_id = $entity_type->id();
+  if (!isset($permissions_entities[$entity_type_id])) {
     return [];
   }
-  $managed_bundles = $permissions_entities[$entity_type->id()];
+  $managed_bundles = $permissions_entities[$entity_type_id];
   if (!in_array($bundle, $managed_bundles)) {
     return [];
   }
   $fields = [];
+  $persistent_map = \Drupal::keyValue('entity.definitions.bundle_field_map');
+  $map = $persistent_map->getAll();
   foreach (openy_gated_content_entity_field_storage_info($entity_type) as $name => $definition) {
     $fields[$name] = $definition;
+    $map[$entity_type_id][$name]['type'] = $definition->getType();
+    $map[$entity_type_id][$name]['bundles'][$bundle] = $bundle;
   }
+  // Delete former incorrect map.
+  $persistent_map->deleteAll();
+  // Add a recent map.
+  $persistent_map->setMultiple($map);
   return $fields;
 }
 


### PR DESCRIPTION
**Related Issue/Ticket:**

https://openy.atlassian.net/browse/PRODDEV-451

## Steps to test:

- [ ] Log in as admin
- [ ] Go to the Shared content source list (/admin/virtual-y/shared-content/server)
- [ ] Edit and submit the OpenY shared server to obtain the token
- [ ] Fetch content, select some video or blog post, and try to get it to your local site
- [ ] Verify it is pulled successfully

![image](https://user-images.githubusercontent.com/5138333/139087244-27b2a84b-5377-41f3-bd89-bd92f9f94e3d.png)

- [ ] Finally observe the issue is resolved.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [x] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
