### PR TITLE
fix: Use Interface, not child Class in order to support other services

### DIFF
--- a/modules/openy_gc_log/src/LogArchiver.php
+++ b/modules/openy_gc_log/src/LogArchiver.php
@@ -6,7 +6,7 @@ use Drupal\Core\Config\ConfigFactory;
 use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Extension\ModuleHandlerInterface;
-use Drupal\Core\File\FileSystem;
+use Drupal\Core\File\FileSystemInterface;
 use Drupal\Core\Logger\LoggerChannel;
 use Drupal\Core\Site\Settings;
 use Drupal\Core\StringTranslation\StringTranslationTrait;
@@ -92,9 +92,9 @@ class LogArchiver {
   private $config;
 
   /**
-   * FileSystem.
+   * FileSystemInterface.
    *
-   * @var \Drupal\Core\File\FileSystem
+   * @var \Drupal\Core\File\FileSystemInterface
    */
   protected $fileSystem;
 
@@ -135,8 +135,8 @@ class LogArchiver {
    *   LoggerChannel.
    * @param \Drupal\Core\Config\ConfigFactory $configFactory
    *   ConfigFactory.
-   * @param \Drupal\Core\File\FileSystem $fileSystem
-   *   FileSystem.
+   * @param \Drupal\Core\File\FileSystemInterface $fileSystem
+   *   FileSystemInterface.
    * @param \Drupal\Core\Site\Settings $settings
    *   Settings.
    * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
@@ -150,7 +150,7 @@ class LogArchiver {
     EntityTypeManager $entityTypeManager,
     LoggerChannel $logger,
     ConfigFactory $configFactory,
-    FileSystem $fileSystem,
+    FileSystemInterface $fileSystem,
     Settings $settings,
     ModuleHandlerInterface $module_handler,
     DateFormatterInterface $date_formatter,


### PR DESCRIPTION
Backport: https://github.com/ymcatwincities/openy_gated_content/pull/167

**Related Issue/Ticket:**
See https://openy.slack.com/archives/C6G4ZTLVC/p1635429557024700

**PLEASE CHECK BASE BRANCH FOR YOUR PR**
**ONLY urgent and approved fixes for point release should go to master branch**

(Replace this line with a link to the related GitHub issue on [ymcatwincities/openy_gated_content](https://github.com/ymcatwincities/openy_gated_content/issues) or your own ticketing system)

## Steps to test:

- [ ] Cron should work when s3fs module installed

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [x] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
