### PR TITLE
[PRODDEV-484] Add patch to resolve indexing error

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,9 @@
             "drupal/jsonapi_image_styles": {
                 "ParseError: syntax error, unexpected 'EntityTypeManagerInterface' (3229668)": "https://www.drupal.org/files/issues/2021-08-24/3229668-2.patch",
                 "TypeError: Argument 1 passed to Drupal\\jsonapi_image_styles\\EventSubscriber\\ConfigSubscriber::onResponse() must be an instance of Symfony\\Component\\HttpKernel\\Event\\ResponseEvent (3229545)": "https://git.drupalcode.org/project/jsonapi_image_styles/-/merge_requests/2/diffs.patch"
+            },
+            "drupal/core": {
+                "[PRODDEV-484] An error occurs after admin indexes the data https://dgo.to/3138528": "https://www.drupal.org/files/issues/2020-05-21/getentitiestoview_change_the_interface_of_the_first_argument_3138528_2.patch"
             }
         },
         "patches-ignore": {

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,10 @@
                 "TypeError: Argument 1 passed to Drupal\\jsonapi_image_styles\\EventSubscriber\\ConfigSubscriber::onResponse() must be an instance of Symfony\\Component\\HttpKernel\\Event\\ResponseEvent (3229545)": "https://git.drupalcode.org/project/jsonapi_image_styles/-/merge_requests/2/diffs.patch"
             },
             "drupal/core": {
-                "[PRODDEV-484] An error occurs after admin indexes the data https://dgo.to/3138528": "https://www.drupal.org/files/issues/2020-05-21/getentitiestoview_change_the_interface_of_the_first_argument_3138528_2.patch"
+                "[PRODDEV-484] An error occurs after admin indexes the data https://dgo.to/3138528": "https://www.drupal.org/files/issues/2020-05-21/getentitiestoview_change_the_interface_of_the_first_argument_3138528_3.patch"
+            },
+            "drupal/blazy": {
+                "[PRODDEV-484] An error occurs after admin indexes the data https://dgo.to/3252140": "https://git.drupalcode.org/project/blazy/-/merge_requests/6.diff"
             }
         },
         "patches-ignore": {


### PR DESCRIPTION
Via https://www.drupal.org/project/drupal/issues/3138528

Do not merge PR, only review it and approve/request changes.
Merge is allowed by QA Engineer only.

**Related Issue/Ticket:** 

**PLEASE CHECK BASE BRANCH FOR YOUR PR**
**ONLY urgent and approved fixes for point release should go to master branch**

https://openy.atlassian.net/browse/PRODDEV-484

## Steps to test:

- [ ] Pull in this branch
- [ ] `composer update --lock` to apply the patch
- [ ] Visit `/admin/modules` and enable `Open Y Virtual YMCA Search`
- [ ] Visit `/admin/config/search/search-api/index/search_content` and index content
- [ ] Observe content is indexed without error.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [x] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
