### PR TITLE
[PRODDEV-479] [PRODDEV-480]  Flag new shared content

### DIFF
--- a/assets/css/admin_ui_styles.css
+++ b/assets/css/admin_ui_styles.css
@@ -18,3 +18,7 @@
 #fetched-data tr.disabled {
   opacity: 0.76;
 }
+
+.ui-dialog .ui-dialog-titlebar-close.no-close {
+    display: none;
+}

--- a/assets/css/admin_ui_styles.css
+++ b/assets/css/admin_ui_styles.css
@@ -14,3 +14,7 @@
 #fetched-data tr.new-item {
     font-weight: bold;
 }
+
+#fetched-data tr.disabled {
+  opacity: 0.76;
+}

--- a/assets/css/admin_ui_styles.css
+++ b/assets/css/admin_ui_styles.css
@@ -10,3 +10,7 @@
   float: left;
   width: calc(100% - 40px);
 }
+
+#fetched-data tr.new-item {
+    font-weight: bold;
+}

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,9 @@
             "drupal/jsonapi_image_styles": {
                 "ParseError: syntax error, unexpected 'EntityTypeManagerInterface' (3229668)": "https://www.drupal.org/files/issues/2021-08-24/3229668-2.patch",
                 "TypeError: Argument 1 passed to Drupal\\jsonapi_image_styles\\EventSubscriber\\ConfigSubscriber::onResponse() must be an instance of Symfony\\Component\\HttpKernel\\Event\\ResponseEvent (3229545)": "https://git.drupalcode.org/project/jsonapi_image_styles/-/merge_requests/2/diffs.patch"
+            },
+            "drupal/core": {
+                "Enable disabling tableselect element options https://www.drupal.org/i/2895352": "https://www.drupal.org/files/issues/2019-12-03/2895352-42-8.8.x.patch"
             }
         },
         "patches-ignore": {

--- a/modules/openy_gc_shared_content/src/Controller/PreviewController.php
+++ b/modules/openy_gc_shared_content/src/Controller/PreviewController.php
@@ -52,14 +52,25 @@ class PreviewController extends ControllerBase {
    * Callback for opening the modal form.
    */
   public function openPreviewModal(Request $request, SharedContentSourceServerInterface $shared_content_source_server, string $type, string $uuid) {
+    // Prepare AjaxResponse.
     $response = new AjaxResponse();
+
+    // Prepare preview in $content.
     $instance = $this->sharedSourceTypeManager->createInstance($type);
     $query_args = $instance->getFullJsonApiQueryArgs();
     $data = $instance->jsonApiCall($shared_content_source_server, $query_args, $uuid);
     $content = $instance->formatItem($data, FALSE);
     $content['#server'] = $shared_content_source_server->getUrl();
+
+    // Prepare the form and send everything we need as extra arguments.
     $form = $this->formBuilder->getForm('Drupal\openy_gc_shared_content\Form\SharedContentPreviewForm', $content, $type, $uuid);
-    $response->addCommand(new OpenModalDialogCommand('Preview', [$content, $form], ['width' => '900']));
+
+    // Open the modal with the content preview and the "fetch" form.
+    $response->addCommand(new OpenModalDialogCommand(
+      'Preview',
+      [$content, $form],
+      ['width' => '900']
+    ));
     return $response;
   }
 

--- a/modules/openy_gc_shared_content/src/Controller/PreviewController.php
+++ b/modules/openy_gc_shared_content/src/Controller/PreviewController.php
@@ -8,6 +8,7 @@ use Drupal\Core\Ajax\OpenModalDialogCommand;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Form\FormBuilder;
 use Drupal\openy_gc_shared_content\Entity\SharedContentSourceServerInterface;
+use Drupal\user\UserDataInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -31,11 +32,19 @@ class PreviewController extends ControllerBase {
   protected $sharedSourceTypeManager;
 
   /**
+   * The user data interface.
+   *
+   * @var \Drupal\user\UserDataInterface
+   */
+  protected $userData;
+
+  /**
    * {@inheritdoc}
    */
-  public function __construct(FormBuilder $formBuilder, PluginManagerInterface $manager) {
+  public function __construct(FormBuilder $formBuilder, PluginManagerInterface $manager, UserDataInterface $user_data) {
     $this->formBuilder = $formBuilder;
     $this->sharedSourceTypeManager = $manager;
+    $this->userData = $user_data;
   }
 
   /**
@@ -44,7 +53,8 @@ class PreviewController extends ControllerBase {
   public static function create(ContainerInterface $container) {
     return new static(
       $container->get('form_builder'),
-      $container->get('plugin.manager.shared_content_source_type')
+      $container->get('plugin.manager.shared_content_source_type'),
+      $container->get('user.data')
     );
   }
 
@@ -54,6 +64,21 @@ class PreviewController extends ControllerBase {
   public function openPreviewModal(Request $request, SharedContentSourceServerInterface $shared_content_source_server, string $type, string $uuid) {
     // Prepare AjaxResponse.
     $response = new AjaxResponse();
+
+    // Update the previewed list with this UUID if it's not already there.
+    $previewed = $this->userData->get(
+      'openy_gc_shared_content',
+      $this->currentUser()->id(),
+      $shared_content_source_server->id() . '_previewed'
+    );
+    if (!in_array($uuid, $previewed)) {
+      $previewed[] = $uuid;
+    }
+    $this->userData->set('openy_gc_shared_content',
+      $this->currentUser()->id(),
+      $shared_content_source_server->id() . '_previewed',
+      $previewed
+    );
 
     // Prepare preview in $content.
     $instance = $this->sharedSourceTypeManager->createInstance($type);

--- a/modules/openy_gc_shared_content/src/Controller/PreviewController.php
+++ b/modules/openy_gc_shared_content/src/Controller/PreviewController.php
@@ -91,10 +91,14 @@ class PreviewController extends ControllerBase {
     $form = $this->formBuilder->getForm('Drupal\openy_gc_shared_content\Form\SharedContentPreviewForm', $content, $type, $uuid);
 
     // Open the modal with the content preview and the "fetch" form.
+    // Hide the regular close button to force users to use ours.
     $response->addCommand(new OpenModalDialogCommand(
       'Preview',
       [$content, $form],
-      ['width' => '900']
+      [
+        'width' => '900',
+        'classes' => ['ui-dialog-titlebar-close' => 'no-close'],
+      ]
     ));
     return $response;
   }

--- a/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
+++ b/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
@@ -250,9 +250,9 @@ class SharedContentFetchForm extends EntityForm {
         '#type' => 'tableselect',
         '#header' => [
           'name' => $this->t('Name'),
-          'donated_date' => $this->t('Donated On'),
-          'donated_by' => $this->t('Donated By'),
-          'count_of_downloads' => $this->t('YMCAS using content'),
+          'donated_date' => $this->t('Donated on'),
+          'donated_by' => $this->t('Donated by'),
+          'count_of_downloads' => $this->t('YMCAs using content'),
           'operations' => [
             'data' => $this->t('Operations'),
           ],

--- a/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
+++ b/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
@@ -142,6 +142,12 @@ class SharedContentFetchForm extends EntityForm {
       ];
     }
     else {
+      // Duplicate the form actions into the action container in the header.
+      $form['fetched_data']['actions'] = parent::actions($form, $form_state);
+      unset($form['fetched_data']['actions']['delete']);
+      $form['fetched_data']['actions']['submit']['#value'] = $this->t('Fetch to my site');
+      $form['fetched_data']['actions']['submit']['#attributes']['class'][] = 'button--primary';
+
       $form['fetched_data']['content'] = [
         '#title' => $this->t('Select content to import'),
         '#type' => 'tableselect',

--- a/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
+++ b/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
@@ -280,7 +280,6 @@ class SharedContentFetchForm extends EntityForm {
         }
 
         $form['fetched_data']['content']['#options'][$item['id']] = [
-          // @todo maybe we can highlight existing items here.
           '#disabled' => $item_exists,
           '#attributes' => [
             'class' => $row_classes,

--- a/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
+++ b/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
@@ -145,7 +145,7 @@ class SharedContentFetchForm extends EntityForm {
     $request_time = $this->time->getRequestTime();
 
     // Content is new when:
-    // 1) the changed date > last time user fetched on their last session.
+    // 1) the created date > last time user fetched on their last session.
     // 2) we're on our first session.
     // 3) it hasn't already been previewed this session.
     //
@@ -268,13 +268,13 @@ class SharedContentFetchForm extends EntityForm {
 
         $donated_date_formatted = '';
         $item_is_new = FALSE;
-        if (!empty($item['attributes']['changed'])) {
+        if (!empty($item['attributes']['created'])) {
           // Fetch the last modified date and format it.
-          $changed = strtotime($item['attributes']['changed']);
-          $donated_date_formatted = $this->dateFormatter->format($changed, 'short');
+          $created = strtotime($item['attributes']['created']);
+          $donated_date_formatted = $this->dateFormatter->format($created, 'short');
 
           // If the item is new then give the row the respective class.
-          $item_is_new = (($changed > $last_session) || $first_session) && !in_array($item['id'], $previewed);
+          $item_is_new = (($created > $last_session) || $first_session) && !in_array($item['id'], $previewed);
           // Add the class if the item is new AND it's not fetched yet.
           $row_classes[] = $item_is_new && !$item_exists ? 'new-item' : [];
         }

--- a/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
+++ b/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
@@ -284,6 +284,7 @@ class SharedContentFetchForm extends EntityForm {
           '#disabled' => $item_exists,
           '#attributes' => [
             'class' => $row_classes,
+            'data-uuid' => $item['id'],
           ],
           'name' => $instance->formatItem($item),
           'donated_date' => $donated_date_formatted,

--- a/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
+++ b/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
@@ -157,7 +157,7 @@ class SharedContentFetchForm extends EntityForm {
     $first_fetched = $user_data->get('openy_gc_shared_content', $user->id(), $entity->id() . '_first_fetched');
     $last_fetched = $user_data->get('openy_gc_shared_content', $user->id(), $entity->id() . '_last_fetched');
     $last_session = $user_data->get('openy_gc_shared_content', $user->id(), $entity->id() . '_last_session');
-    $previewed = $user_data->get('openy_gc_shared_content', $user->id(), $entity->id() . '_previewed');
+    $previewed = $user_data->get('openy_gc_shared_content', $user->id(), $entity->id() . '_previewed') ?: [];
 
     // There are two cases that could mean we're on our first session:
     // 1) first_fetch is not set, OR

--- a/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
+++ b/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
@@ -241,7 +241,7 @@ class SharedContentFetchForm extends EntityForm {
         '#type' => 'tableselect',
         '#header' => [
           'name' => $this->t('Name'),
-          'donated_date' => $this->t('Date Added'),
+          'donated_date' => $this->t('Donated On'),
           'donated_by' => $this->t('Donated By'),
           'count_of_downloads' => $this->t('YMCAS using content'),
           'operations' => [

--- a/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
+++ b/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
@@ -163,6 +163,7 @@ class SharedContentFetchForm extends EntityForm {
 
         $form['fetched_data']['content']['#options'][$item['id']] = [
           // @todo maybe we can highlight existing items here.
+          '#disabled' => $item_exists,
           'name' => $instance->formatItem($item),
           'donated_by' => !empty($item['attributes']['field_gc_origin']) ? $item['attributes']['field_gc_origin'] : ' ',
           'count_of_downloads' => !empty($item['attributes']['field_share_count']) ? $item['attributes']['field_share_count'] : '0',

--- a/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
+++ b/modules/openy_gc_shared_content/src/Form/SharedContentFetchForm.php
@@ -4,8 +4,8 @@ namespace Drupal\openy_gc_shared_content\Form;
 
 use Drupal\Component\Plugin\PluginManagerInterface;
 use Drupal\Core\Batch\BatchBuilder;
-use Drupal\Core\Entity\EntityRepository;
 use Drupal\Core\Entity\EntityForm;
+use Drupal\Core\Entity\EntityRepository;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Pager\PagerManagerInterface;
 use Drupal\Core\Render\Element;

--- a/modules/openy_gc_shared_content/src/Form/SharedContentPreviewForm.php
+++ b/modules/openy_gc_shared_content/src/Form/SharedContentPreviewForm.php
@@ -122,7 +122,9 @@ class SharedContentPreviewForm extends FormBase {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     // Fetch the item using the arguments passed in $form_state.
-    $this->fetchItem($form_state);
+    if ($form_state->getTriggeringElement()['#value']->__toString() !== 'Close') {
+      $this->fetchItem($form_state);
+    }
   }
 
   /**
@@ -143,6 +145,9 @@ class SharedContentPreviewForm extends FormBase {
 
     if ($form_state->getTriggeringElement()['#value']->__toString() == 'Close') {
       $response->addCommand(new CloseModalDialogCommand());
+      $response
+        ->addCommand(new RedirectCommand($this->requestStack->getCurrentRequest()->server->get('HTTP_REFERER')));
+      return $response;
     }
     else {
 

--- a/modules/openy_gc_shared_content/src/Form/SharedContentPreviewForm.php
+++ b/modules/openy_gc_shared_content/src/Form/SharedContentPreviewForm.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Drupal\openy_gc_shared_content\Form;
+
+use Drupal\Component\Plugin\PluginManagerInterface;
+use Drupal\Component\Render\FormattableMarkup;
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Ajax\CloseDialogCommand;
+use Drupal\Core\Ajax\CloseModalDialogCommand;
+use Drupal\Core\Ajax\OpenModalDialogCommand;
+use Drupal\Core\Ajax\RedirectCommand;
+use Drupal\Core\Ajax\ReplaceCommand;
+use Drupal\Core\Form\FormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Url;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Implements the ModalForm form controller.
+ *
+ * This example demonstrates implementation of a form that is designed to be
+ * used as a modal form.  To properly display the modal the link presented by
+ * the \Drupal\form_api_example\Controller\Page page controller loads the Drupal
+ * dialog and ajax libraries.  The submit handler in this class returns ajax
+ * commands to replace text in the calling page after submission .
+ *
+ * @see \Drupal\Core\Form\FormBase
+ */
+class SharedContentPreviewForm extends FormBase {
+
+  /**
+   * The plugin manager for SharedContentSourceType classes.
+   *
+   * @var \Drupal\Component\Plugin\PluginManagerInterface
+   */
+  protected $sharedSourceTypeManager;
+
+  /**
+   * The Symfony request stack.
+   *
+   * @var \Symfony\Component\HttpFoundation\RequestStack
+   */
+  protected $requestStack;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(PluginManagerInterface $manager, RequestStack $request_stack) {
+    $this->sharedSourceTypeManager = $manager;
+    $this->requestStack = $request_stack;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+
+    return new static(
+      $container->get('plugin.manager.shared_content_source_type'),
+      $container->get('request_stack'),
+      $container->get('string_translation'),
+      $container->get('messenger'),
+      $container->get('request_stack')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'shared_content_preview_form';
+  }
+
+  /**
+   * Helper method so we can have consistent dialog options.
+   *
+   * @return string[]
+   *   An array of jQuery UI elements to pass on to our dialog form.
+   */
+  protected static function getDataDialogOptions() {
+    return [
+      'width' => '80%',
+    ];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+
+    // Add the core AJAX library.
+    $form['#attached']['library'][] = 'core/drupal.ajax';
+
+    // Group submit handlers in an actions element with a key of "actions" so
+    // that it gets styled correctly, and so that other modules may add actions
+    // to the form.
+    $form['actions'] = [
+      '#type' => 'actions',
+    ];
+
+    $form['actions']['close'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Close'),
+      '#ajax' => [
+        'callback' => '::ajaxSubmitForm',
+        'event' => 'click',
+      ],
+    ];
+    // Add a submit button that handles the submission of the form.
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this
+        ->t('Fetch to my site'),
+      '#ajax' => [
+        'callback' => '::ajaxSubmitForm',
+        'event' => 'click',
+      ],
+      '#attributes' => ['class' => ['button--primary']],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    // Fetch the item using the arguments passed in $form_state.
+    $this->fetchItem($form_state);
+  }
+
+  /**
+   * Implements the submit handler for the modal dialog AJAX call.
+   *
+   * @param array $form
+   *   Render array representing from.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   Current form state.
+   *
+   * @return \Drupal\Core\Ajax\AjaxResponse
+   *   Array of AJAX commands to execute on submit of the modal form.
+   */
+  public function ajaxSubmitForm(array &$form, FormStateInterface $form_state) {
+
+    // We begin building a new ajax response.
+    $response = new AjaxResponse();
+
+    if ($form_state->getTriggeringElement()['#value']->__toString() == 'Close') {
+      $response->addCommand(new CloseModalDialogCommand());
+    }
+    else {
+
+      // We don't want any messages that were added by submitForm().
+      $this
+        ->messenger()
+        ->deleteAll();
+
+      // Fetch the item using the arguments passed in $form_state.
+      $this->fetchItem($form_state);
+
+      // Redirect to the parent page.
+      // @todo It would be better to reload the parent form with ajax.
+      $response
+        ->addCommand(new RedirectCommand($this->requestStack->getCurrentRequest()->server->get('HTTP_REFERER')));
+    }
+
+    // Finally return our response.
+    return $response;
+  }
+
+  /**
+   * Get item info from form and fetch it.
+   */
+  public function fetchItem(FormStateInterface $form_state) {
+    $url = $form_state->getBuildInfo()['args'][0]['#server'];
+    $uuid = $form_state->getBuildInfo()['args'][2];
+    $type = $form_state->getBuildInfo()['args'][1];
+
+    return $this->processItem($url, $uuid, $type);
+  }
+
+  /**
+   * Processor for batch operations.
+   */
+  public function processItem($url, $uuid, $type) {
+    $instance = $this->sharedSourceTypeManager->createInstance($type);
+    $instance->saveFromSource($url, $uuid);
+  }
+
+}

--- a/modules/openy_gc_shared_content/src/Form/SharedContentPreviewForm.php
+++ b/modules/openy_gc_shared_content/src/Form/SharedContentPreviewForm.php
@@ -79,9 +79,6 @@ class SharedContentPreviewForm extends FormBase {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-
-    
-
     // Group submit handlers in an actions element with a key of "actions" so
     // that it gets styled correctly, and so that other modules may add actions
     // to the form.

--- a/modules/openy_gc_shared_content/src/Form/SharedContentPreviewForm.php
+++ b/modules/openy_gc_shared_content/src/Form/SharedContentPreviewForm.php
@@ -80,8 +80,7 @@ class SharedContentPreviewForm extends FormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
 
-    // Add the core AJAX library.
-    $form['#attached']['library'][] = 'core/drupal.ajax';
+    
 
     // Group submit handlers in an actions element with a key of "actions" so
     // that it gets styled correctly, and so that other modules may add actions

--- a/modules/openy_gc_shared_content/src/Form/SharedContentPreviewForm.php
+++ b/modules/openy_gc_shared_content/src/Form/SharedContentPreviewForm.php
@@ -14,15 +14,9 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * Implements the ModalForm form controller.
+ * Implements the SharedContentPreviewForm form controller.
  *
- * This example demonstrates implementation of a form that is designed to be
- * used as a modal form.  To properly display the modal the link presented by
- * the \Drupal\form_api_example\Controller\Page page controller loads the Drupal
- * dialog and ajax libraries.  The submit handler in this class returns ajax
- * commands to replace text in the calling page after submission .
- *
- * @see \Drupal\Core\Form\FormBase
+ * @internal
  */
 class SharedContentPreviewForm extends FormBase {
 

--- a/modules/openy_gc_shared_content/src/Form/SharedContentPreviewForm.php
+++ b/modules/openy_gc_shared_content/src/Form/SharedContentPreviewForm.php
@@ -121,10 +121,7 @@ class SharedContentPreviewForm extends FormBase {
    * {@inheritdoc}
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
-    // Fetch the item using the arguments passed in $form_state.
-    if ($form_state->getTriggeringElement()['#value']->__toString() !== 'Close') {
-      $this->fetchItem($form_state);
-    }
+    // Do nothing here. All actions are in ajaxSubmitForm.
   }
 
   /**
@@ -145,6 +142,7 @@ class SharedContentPreviewForm extends FormBase {
 
     if ($form_state->getTriggeringElement()['#value']->__toString() == 'Close') {
       $response->addCommand(new CloseModalDialogCommand());
+      // @todo It would be better to reload the parent form with ajax.
       $response
         ->addCommand(new RedirectCommand($this->requestStack->getCurrentRequest()->server->get('HTTP_REFERER')));
       return $response;

--- a/modules/openy_gc_shared_content/src/Form/SharedContentPreviewForm.php
+++ b/modules/openy_gc_shared_content/src/Form/SharedContentPreviewForm.php
@@ -3,16 +3,11 @@
 namespace Drupal\openy_gc_shared_content\Form;
 
 use Drupal\Component\Plugin\PluginManagerInterface;
-use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Ajax\AjaxResponse;
-use Drupal\Core\Ajax\CloseDialogCommand;
 use Drupal\Core\Ajax\CloseModalDialogCommand;
-use Drupal\Core\Ajax\OpenModalDialogCommand;
 use Drupal\Core\Ajax\RedirectCommand;
-use Drupal\Core\Ajax\ReplaceCommand;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Drupal\Core\Url;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/modules/openy_gc_shared_content/src/Form/SharedContentPreviewForm.php
+++ b/modules/openy_gc_shared_content/src/Form/SharedContentPreviewForm.php
@@ -8,8 +8,8 @@ use Drupal\Core\Ajax\CloseModalDialogCommand;
 use Drupal\Core\Ajax\RedirectCommand;
 use Drupal\Core\Form\FormBase;
 use Drupal\Core\Form\FormStateInterface;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Implements the ModalForm form controller.

--- a/modules/openy_gc_shared_content/src/Plugin/SharedContentSourceType/VirtualYBlogPost.php
+++ b/modules/openy_gc_shared_content/src/Plugin/SharedContentSourceType/VirtualYBlogPost.php
@@ -21,7 +21,7 @@ class VirtualYBlogPost extends SharedContentSourceTypeBase {
    */
   public function getTeaserJsonApiQueryArgs() {
     return [
-      'sort[sortByDate][path]' => 'created',
+      'sort[sortByDate][path]' => 'changed',
       'sort[sortByDate][direction]' => 'DESC',
       'filter[status]' => 1,
       'filter[field_gc_share]' => 1,

--- a/modules/openy_gc_shared_content/src/Plugin/SharedContentSourceType/VirtualYVideo.php
+++ b/modules/openy_gc_shared_content/src/Plugin/SharedContentSourceType/VirtualYVideo.php
@@ -21,7 +21,7 @@ class VirtualYVideo extends SharedContentSourceTypeBase {
    */
   public function getTeaserJsonApiQueryArgs() {
     return [
-      'sort[sortByDate][path]' => 'changed',
+      'sort[sortByDate][path]' => 'created',
       'sort[sortByDate][direction]' => 'DESC',
       'filter[status]' => 1,
       'filter[field_gc_share]' => 1,

--- a/modules/openy_gc_shared_content/src/Plugin/SharedContentSourceType/VirtualYVideo.php
+++ b/modules/openy_gc_shared_content/src/Plugin/SharedContentSourceType/VirtualYVideo.php
@@ -21,7 +21,7 @@ class VirtualYVideo extends SharedContentSourceTypeBase {
    */
   public function getTeaserJsonApiQueryArgs() {
     return [
-      'sort[sortByDate][path]' => 'created',
+      'sort[sortByDate][path]' => 'changed',
       'sort[sortByDate][direction]' => 'DESC',
       'filter[status]' => 1,
       'filter[field_gc_share]' => 1,

--- a/modules/openy_gc_shared_content/src/SharedContentSourceTypeBase.php
+++ b/modules/openy_gc_shared_content/src/SharedContentSourceTypeBase.php
@@ -423,9 +423,8 @@ class SharedContentSourceTypeBase extends PluginBase implements SharedContentSou
       $entity->set('field_gc_origin', $url);
       $entity->save();
 
-      $this->messenger()->addStatus($this->t('Entity {@type:@bundle} "@title" was fetched to site.', [
-        '@type' => $this->getEntityType(),
-        '@bundle' => $this->getEntityBundle(),
+      $this->messenger()->addStatus($this->t('The @label "@title" was fetched to the site.', [
+        '@label' => $this->getLabel(),
         '@title' => $entity->get('title')->value,
       ]));
       return TRUE;


### PR DESCRIPTION
Do not merge PR, only review it and approve/request changes.
Merge is allowed by QA Engineer only.

**Related Issue/Ticket:**

**PLEASE CHECK BASE BRANCH FOR YOUR PR**
**ONLY urgent and approved fixes for point release should go to master branch**

https://openy.atlassian.net/browse/PRODDEV-479
https://openy.atlassian.net/browse/PRODDEV-480

## Steps to test:

You will need to have a site connected to a shared content server in order to test and have the shared content server all configured.

Check out this video: 

https://user-images.githubusercontent.com/238201/145146512-354e3c73-8feb-47c8-98cc-c45ae9312ccd.mp4


- [ ] Observe "Fetch to my site" button is duplicated on the top of the form.
![Fetch_shared_content___Drush_Site-Install](https://user-images.githubusercontent.com/238201/144768539-093f1559-20f3-4b95-adb0-584bdf2792e2.png)
- [ ] Observe top "Fetch to my site" button works exactly the same as the bottom button.

- [ ] Observe once content is added to a site, the checkbox and button are disabled and the button text changes from "Preview" to "Added"
![Fetch_shared_content___Drush_Site-Install](https://user-images.githubusercontent.com/238201/144768594-ccbc0f62-3bc2-4bca-9cb4-4e2fa62c751a.png)

- [ ] Observe when you click "Preview" a "Fetch to my site" button that fetches content when clicked.
- [ ] Observe close button that closes the preview with no action.

![Fetch_shared_content___Drush_Site-Install](https://user-images.githubusercontent.com/238201/144768624-5ed728ce-97be-4841-8cbb-e6ee06dcd408.png)

- [ ] Observe content is bolded when new (or when it's your first session)
- [ ] Observe content is unbolded when you Preview it and then close the modal.
- [ ] Observe content is unbolded when you start a new session.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
