### PR TITLE
[PRODDEV-228] Rebuild shared content

### DIFF
--- a/modules/openy_gc_shared_content/openy_gc_shared_content.routing.yml
+++ b/modules/openy_gc_shared_content/openy_gc_shared_content.routing.yml
@@ -65,3 +65,15 @@ entity.shared_content_source_server.preview:
         type: string
       uuid:
         type: string
+
+shared_content_source.shared:
+  path: '/api/virtual-y/shared-content-source/{type}'
+  defaults:
+    _controller: '\Drupal\openy_gc_shared_content\Controller\SharedContentController::index'
+    _title: 'Shared content'
+  requirements:
+    _access: 'TRUE'
+  options:
+    parameters:
+      type:
+        type: string

--- a/modules/openy_gc_shared_content/openy_gc_shared_content.routing.yml
+++ b/modules/openy_gc_shared_content/openy_gc_shared_content.routing.yml
@@ -72,7 +72,7 @@ shared_content_source.shared:
     _controller: '\Drupal\openy_gc_shared_content\Controller\SharedContentController::index'
     _title: 'Shared content'
   requirements:
-    _access: 'TRUE'
+    _custom_access: '\Drupal\openy_gc_shared_content\Controller\SharedContentController::access'
   options:
     parameters:
       type:

--- a/modules/openy_gc_shared_content/src/Controller/SharedContentController.php
+++ b/modules/openy_gc_shared_content/src/Controller/SharedContentController.php
@@ -93,13 +93,14 @@ class SharedContentController extends ControllerBase {
       ->condition('status', 1)
       ->sort('created', 'DESC')
       ->accessCheck(TRUE);
-    $nodes_ids = $query->execute();
+    $node_ids = $query->execute();
 
-    if ($nodes_ids) {
-      foreach ($nodes_ids as $node_id) {
-        /** @var Drupal\node\Entity\Node $node */
-        $node = $node_storage->load($node_id);
+    // Make sure nodes have been returned as loadMultiple will load all
+    // entities on a null parameter.
+    if (!empty($node_ids)) {
+      $nodes = $node_storage->loadMultiple($node_ids);
 
+      foreach ($nodes as $node) {
         if (!$node->access('view')) {
           $access_denied = TRUE;
           break;
@@ -145,7 +146,6 @@ class SharedContentController extends ControllerBase {
           }
         }
       }
-
     }
 
     if ($access_denied) {

--- a/modules/openy_gc_shared_content/src/Controller/SharedContentController.php
+++ b/modules/openy_gc_shared_content/src/Controller/SharedContentController.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Drupal\openy_gc_shared_content\Controller;
+
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Datetime\DateFormatter;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+/**
+ * The SharedContentController class.
+ */
+class SharedContentController extends ControllerBase {
+
+  /**
+   * The date formatter.
+   *
+   * @var \Drupal\Core\Datetime\DateFormatter
+   */
+  protected $dateFormatter;
+
+  /**
+   * SharedContentController constructor.
+   *
+   * @param \Drupal\Core\Datetime\DateFormatter $date_formatter
+   *   The date formatter.
+   */
+  public function __construct(DateFormatter $date_formatter) {
+    $this->dateFormatter = $date_formatter;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('date.formatter')
+    );
+  }
+
+  /**
+   * Return the data.
+   *
+   * @return Symfony\Component\HttpFoundation\JsonResponse
+   *   Return the JSON data.
+   */
+  public function index(string $type) {
+    if (!in_array($type, ['gc_video', 'vy_blog_post'])) {
+      return new JsonResponse(['error' => ['code' => '400']], 400);
+    }
+
+    return new JsonResponse([
+      'data' => $this->getData($type),
+      'method' => 'GET',
+      'status' => 200,
+    ]);
+  }
+
+  /**
+   * Get the data to be returned.
+   *
+   * @return array
+   *   The data to be returned.
+   */
+  public function getData($type) {
+    $node_storage = $this->entityTypeManager()->getStorage('node');
+
+    $result = [];
+    $query = $node_storage->getQuery()
+      ->condition('type', $type)
+      ->sort('nid', 'ASC');
+    $nodes_ids = $query->execute();
+    if ($nodes_ids) {
+      foreach ($nodes_ids as $node_id) {
+        /** @var Drupal\node\Entity\Node $node */
+        $node = $node_storage->load($node_id);
+
+        $attributes = [
+          "nid" => $node->id(),
+          "title" => $node->getTitle(),
+          "created" => $this->dateFormatter->format(
+            $node->getCreatedTime(),
+            'custom',
+            'c'
+          ),
+          "changed" => $this->dateFormatter->format(
+            $node->getChangedTime(),
+            'custom',
+            'c'
+          ),
+          "status" => $node->isPublished(),
+        ];
+
+        switch ($type) {
+          case "gc_video":
+            $result[] = $attributes + [
+              "field_gc_video_instructor" => $node->field_gc_video_instructor->value,
+              "field_gc_video_media_id" => $node->field_gc_video_media->entity ?
+                $node->field_gc_video_media->entity->uuid() : NULL,
+              "field_gc_video_description" => $node->field_gc_video_description->value,
+              "field_gc_video_duration" => $node->field_gc_video_duration->value,
+              "field_gc_video_image_id" => $node->field_gc_video_image->entity ?
+                $node->field_gc_video_image->entity->uuid() : NULL,
+              "field_gc_video_category_id" => $node->field_gc_video_category->entity ?
+                $node->field_gc_video_category->entity->uuid() : NULL,
+              "field_gc_video_equipment_id" => $node->field_gc_video_equipment->entity ?
+                $node->field_gc_video_equipment->entity->uuid() : NULL,
+              "field_gc_video_level_id" => $node->field_gc_video_level->entity ?
+                $node->field_gc_video_level->entity->uuid() : NULL,
+            ];
+            break;
+
+          case "vy_blog_post":
+            $result[] = $attributes + [
+              "field_vy_blog_description" => $node->field_vy_blog_description->value,
+              "field_vy_blog_image_id" => $node->field_vy_blog_image->entity ?
+                $node->field_vy_blog_image->entity->uuid() : NULL,
+            ];
+            break;
+        }
+
+      }
+    }
+    return $result;
+  }
+
+}

--- a/modules/openy_gc_shared_content/src/Controller/SharedContentController.php
+++ b/modules/openy_gc_shared_content/src/Controller/SharedContentController.php
@@ -2,10 +2,10 @@
 
 namespace Drupal\openy_gc_shared_content\Controller;
 
+use Drupal\Core\Access\AccessResult;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Datetime\DateFormatter;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\Core\Access\AccessResult;
 use Drupal\media\Plugin\media\Source\Image;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -112,7 +112,8 @@ class SharedContentController extends ControllerBase {
         foreach (end($result) as $field => $values) {
           if (strstr($field, 'field_')) {
             foreach ($values as $value) {
-              if (isset($value['target_type']) && in_array($value['target_type'], ['taxonomy_term', 'media'])) {
+              if (isset($value['target_type']) && in_array(
+                $value['target_type'], ['taxonomy_term', 'media'])) {
                 // We don't need this back-reference.
                 unset($value['target_uuid']);
                 // Start building the array with field names as the key.

--- a/modules/openy_gc_shared_content/src/Controller/SharedContentController.php
+++ b/modules/openy_gc_shared_content/src/Controller/SharedContentController.php
@@ -82,7 +82,7 @@ class SharedContentController extends ControllerBase {
     $serializer = $this->serializer;
 
     $result = [];
-    $included = [];
+    $included = $included_loaded = [];
     $meta = [];
     $access_denied = FALSE;
 
@@ -130,7 +130,6 @@ class SharedContentController extends ControllerBase {
       }
 
       // Recurse through the references and load the actual entities.
-      $included_loaded = [];
       foreach ($included as $field => $values) {
         foreach ($values as $value) {
           // Load the entity, then normalize it to an array.

--- a/modules/openy_gc_shared_content/src/Controller/SharedContentController.php
+++ b/modules/openy_gc_shared_content/src/Controller/SharedContentController.php
@@ -149,7 +149,7 @@ class SharedContentController extends ControllerBase {
     }
 
     if ($access_denied) {
-      $meta = ['omitted' => ["detail" => $this->t("Some resources have been omitted because of insufficient authorization.")]];
+      $meta = ['omitted' => ['detail' => $this->t('Some resources have been omitted because of insufficient authorization.')]];
     }
 
     return ['data' => $result, 'included' => $included_loaded, 'meta' => $meta];

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_file_blog.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_file_blog.yml
@@ -28,9 +28,10 @@ source:
     - name: id
       label: 'id'
       selector: /uuid/0/value
-    # - name: type
-    #   label: 'Include type'
-    #   selector: /type
+    # Retained for backwards-compatibility.
+    - name: type
+      label: 'Include type'
+      selector: /type
     - name: created
       label: 'Created'
       selector: /created/0/value
@@ -56,11 +57,12 @@ source:
     DOMAIN: replace_me
     DRUPAL_FILE_DIRECTORY: 'public://virtual-y-shared-images/'
 process:
-  # type:
-  #   plugin: skip_on_value
-  #   method: row
-  #   source: type
-  #   value: media--image
+  # Retained for backwards-compatibility.
+  type:
+    plugin: skip_on_value
+    method: row
+    source: type
+    value: media--image
   langcode:
     plugin: default_value
     source: language

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_file_blog.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_file_blog.yml
@@ -8,8 +8,9 @@ label: 'Import Shared VirtualY files'
 migration_group: virtual_y_shared
 source:
   entity_type: vy_blog_post
-  # json_includes:
-  #   - field_vy_blog_image.field_media_image
+  # Retained for backwards-compatibility.
+  json_includes:
+    - field_vy_blog_image.field_media_image
   plugin: url
   data_fetcher_plugin: http
   # Specifies the JSON parser plugin.

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_file_blog.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_file_blog.yml
@@ -8,8 +8,8 @@ label: 'Import Shared VirtualY files'
 migration_group: virtual_y_shared
 source:
   entity_type: vy_blog_post
-  json_includes:
-    - field_vy_blog_image.field_media_image
+  # json_includes:
+  #   - field_vy_blog_image.field_media_image
   plugin: url
   data_fetcher_plugin: http
   # Specifies the JSON parser plugin.
@@ -22,32 +22,32 @@ source:
     x-shared-referer: SHARED_CONTENT_REFERRER_WEBSITE
     authorization: SHARED_CONTENT_CONNECTION_TOKEN
   urls: replace_me
-  item_selector: included/
+  item_selector: included/file
   fields:
     - name: id
       label: 'id'
-      selector: /id
-    - name: type
-      label: 'Include type'
-      selector: /type
+      selector: /uuid/0/value
+    # - name: type
+    #   label: 'Include type'
+    #   selector: /type
     - name: created
       label: 'Created'
-      selector: /attributes/created
+      selector: /created/0/value
     - name: changed
       label: 'Changed'
-      selector: /attributes/changed
+      selector: /changed/0/value
     - name: status
       label: 'Status'
-      selector: /attributes/status
+      selector: /status/0/value
     - name: filename
       label: 'FileName'
-      selector: /attributes/filename
+      selector: /filename/0/value
     - name: filemime
       label: 'FileMIME'
-      selector: /attributes/filemime
+      selector: /filemime/0/value
     - name: url
       label: 'File url'
-      selector: /attributes/uri/url
+      selector: /uri/0/url
   ids:
     id:
       type: string
@@ -55,11 +55,11 @@ source:
     DOMAIN: replace_me
     DRUPAL_FILE_DIRECTORY: 'public://virtual-y-shared-images/'
 process:
-  type:
-    plugin: skip_on_value
-    method: row
-    source: type
-    value: media--image
+  # type:
+  #   plugin: skip_on_value
+  #   method: row
+  #   source: type
+  #   value: media--image
   langcode:
     plugin: default_value
     source: language

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_file_video.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_file_video.yml
@@ -8,8 +8,8 @@ label: 'Import Shared VirtualY files'
 migration_group: virtual_y_shared
 source:
   entity_type: gc_video
-  json_includes:
-    - field_gc_video_image.field_media_image
+  # json_includes:
+  #   - field_gc_video_image.field_media_image
   plugin: url
   data_fetcher_plugin: http
   # Specifies the JSON parser plugin.
@@ -22,32 +22,32 @@ source:
     x-shared-referer: SHARED_CONTENT_REFERRER_WEBSITE
     authorization: SHARED_CONTENT_CONNECTION_TOKEN
   urls: replace_me
-  item_selector: included/
+  item_selector: included/file
   fields:
     - name: id
       label: 'id'
-      selector: /id
-    - name: type
-      label: 'Include type'
-      selector: /type
+      selector: /uuid/0/value
+    # - name: type
+    #   label: 'Include type'
+    #   selector: /type
     - name: created
       label: 'Created'
-      selector: /attributes/created
+      selector: /created/0/value
     - name: changed
       label: 'Changed'
-      selector: /attributes/changed
+      selector: /changed/0/value
     - name: status
       label: 'Status'
-      selector: /attributes/status
+      selector: /status/0/value
     - name: filename
       label: 'FileName'
-      selector: /attributes/filename
+      selector: /filename/0/value
     - name: filemime
       label: 'FileMIME'
-      selector: /attributes/filemime
+      selector: /filemime/0/value
     - name: url
       label: 'File url'
-      selector: /attributes/uri/url
+      selector: /uri/0/url
   ids:
     id:
       type: string
@@ -55,11 +55,11 @@ source:
     DOMAIN: replace_me
     DRUPAL_FILE_DIRECTORY: 'public://virtual-y-shared-images/'
 process:
-  type:
-    plugin: skip_on_value
-    method: row
-    source: type
-    value: media--image
+  # type:
+  #   plugin: skip_on_value
+  #   method: row
+  #   source: type
+  #   value: media--image
   langcode:
     plugin: default_value
     source: language

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_file_video.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_file_video.yml
@@ -28,9 +28,10 @@ source:
     - name: id
       label: 'id'
       selector: /uuid/0/value
-    # - name: type
-    #   label: 'Include type'
-    #   selector: /type
+    # Retained for backwards-compatibility.
+    - name: type
+      label: 'Include type'
+      selector: /type
     - name: created
       label: 'Created'
       selector: /created/0/value
@@ -56,11 +57,12 @@ source:
     DOMAIN: replace_me
     DRUPAL_FILE_DIRECTORY: 'public://virtual-y-shared-images/'
 process:
-  # type:
-  #   plugin: skip_on_value
-  #   method: row
-  #   source: type
-  #   value: media--image
+  # Retained for backwards-compatibility.
+  type:
+    plugin: skip_on_value
+    method: row
+    source: type
+    value: media--image
   langcode:
     plugin: default_value
     source: language

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_file_video.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_file_video.yml
@@ -8,8 +8,9 @@ label: 'Import Shared VirtualY files'
 migration_group: virtual_y_shared
 source:
   entity_type: gc_video
-  # json_includes:
-  #   - field_gc_video_image.field_media_image
+  # Retained for backwards-compatibility.
+  json_includes:
+    - field_gc_video_image.field_media_image
   plugin: url
   data_fetcher_plugin: http
   # Specifies the JSON parser plugin.

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_gc_category.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_gc_category.yml
@@ -10,8 +10,9 @@ deriver: Drupal\openy_gc_shared_content_server\SourceMigrationDeriver
 label: 'GC Category'
 source:
   entity_type: gc_video
-  # json_includes:
-  #   - field_gc_video_category
+  # Retained for backwards-compatibility.
+  json_includes:
+    - field_gc_video_category
   plugin: url
   data_fetcher_plugin: http
   # Specifies the JSON parser plugin.

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_gc_category.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_gc_category.yml
@@ -10,8 +10,8 @@ deriver: Drupal\openy_gc_shared_content_server\SourceMigrationDeriver
 label: 'GC Category'
 source:
   entity_type: gc_video
-  json_includes:
-    - field_gc_video_category
+  # json_includes:
+  #   - field_gc_video_category
   plugin: url
   data_fetcher_plugin: http
   # Specifies the JSON parser plugin.
@@ -26,14 +26,14 @@ source:
   urls: replace_me
   constants:
     DOMAIN: replace_me
-  item_selector: included/
+  item_selector: included/field_gc_video_category
   fields:
     - name: id
       label: 'id'
-      selector: /id
+      selector: /uuid/0/value
     - name: title
       label: 'title'
-      selector: /attributes/name
+      selector: /name/0/value
   ids:
     id:
       type: string

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_gc_category_blog.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_gc_category_blog.yml
@@ -1,0 +1,57 @@
+langcode: en
+status: true
+dependencies:
+  enforced:
+    module:
+      - openy_gc_shared_content_server
+id: virtual_y_shared_gc_category_blog
+migration_group: virtual_y_shared
+deriver: Drupal\openy_gc_shared_content_server\SourceMigrationDeriver
+label: 'GC Category (for Blogs)'
+source:
+  entity_type: vy_blog_post
+  # Retained for backwards-compatibility.
+  json_includes:
+    - field_gc_video_category
+  plugin: url
+  data_fetcher_plugin: http
+  # Specifies the JSON parser plugin.
+  data_parser_plugin: virtualy_json
+  track_changes: true
+  headers:
+    Accept: 'application/json; charset=utf-8'
+    Content-Type: 'application/json'
+    x-shared-content: 1
+    x-shared-referer: SHARED_CONTENT_REFERRER_WEBSITE
+    authorization: SHARED_CONTENT_CONNECTION_TOKEN
+  urls: replace_me
+  constants:
+    DOMAIN: replace_me
+  item_selector: included/field_gc_video_category
+  fields:
+    - name: id
+      label: 'id'
+      selector: /uuid/0/value
+    - name: title
+      label: 'title'
+      selector: /name/0/value
+  ids:
+    id:
+      type: string
+process:
+  langcode:
+    plugin: default_value
+    source: language
+    default_value: en
+  status:
+    plugin: default_value
+    default_value: 1
+  name: title
+  # @todo: This creates duplicate entries with video categories. Need process
+  # plugin to skip import if term already exists.
+destination:
+  plugin: entity:taxonomy_term
+  default_bundle: gc_category
+
+migration_dependencies:
+  optional: {  }

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_gc_equipment.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_gc_equipment.yml
@@ -12,8 +12,8 @@ deriver: Drupal\openy_gc_shared_content_server\SourceMigrationDeriver
 label: 'GC Equipment'
 source:
   entity_type: gc_video
-  json_includes:
-    - field_gc_video_equipment
+  # json_includes:
+  #   - field_gc_video_equipment
   plugin: url
   data_fetcher_plugin: http
   # Specifies the JSON parser plugin.
@@ -28,14 +28,14 @@ source:
   urls: replace_me
   constants:
     DOMAIN: replace_me
-  item_selector: included/
+  item_selector: included/field_gc_video_equipment
   fields:
     - name: id
       label: 'id'
-      selector: /id
+      selector: /uuid/0/value
     - name: title
       label: 'title'
-      selector: /attributes/name
+      selector: /name/0/value
   ids:
     id:
       type: string

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_gc_equipment.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_gc_equipment.yml
@@ -12,8 +12,9 @@ deriver: Drupal\openy_gc_shared_content_server\SourceMigrationDeriver
 label: 'GC Equipment'
 source:
   entity_type: gc_video
-  # json_includes:
-  #   - field_gc_video_equipment
+  # Retained for backwards-compatibility.
+  json_includes:
+    - field_gc_video_equipment
   plugin: url
   data_fetcher_plugin: http
   # Specifies the JSON parser plugin.

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_gc_level.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_gc_level.yml
@@ -12,8 +12,9 @@ deriver: Drupal\openy_gc_shared_content_server\SourceMigrationDeriver
 label: 'GC Level'
 source:
   entity_type: gc_video
-  # json_includes:
-  #   - field_gc_video_level
+  # Retained for backwards-compatibility.
+  json_includes:
+    - field_gc_video_level
   plugin: url
   data_fetcher_plugin: http
   # Specifies the JSON parser plugin.

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_gc_level.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_gc_level.yml
@@ -12,8 +12,8 @@ deriver: Drupal\openy_gc_shared_content_server\SourceMigrationDeriver
 label: 'GC Level'
 source:
   entity_type: gc_video
-  json_includes:
-    - field_gc_video_level
+  # json_includes:
+  #   - field_gc_video_level
   plugin: url
   data_fetcher_plugin: http
   # Specifies the JSON parser plugin.
@@ -28,14 +28,14 @@ source:
   urls: replace_me
   constants:
     DOMAIN: replace_me
-  item_selector: included/
+  item_selector: included/field_gc_video_level
   fields:
     - name: id
       label: 'id'
-      selector: /id
+      selector: /uuid/0/value
     - name: title
       label: 'title'
-      selector: /attributes/name
+      selector: /name/0/value
   ids:
     id:
       type: string

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_blog_image.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_blog_image.yml
@@ -29,9 +29,10 @@ source:
     - name: id
       label: 'id'
       selector: /uuid/0/value
-    # - name: type
-    #   label: 'Include type'
-    #   selector: /type
+    # Retained for backwards-compatibility.
+    - name: type
+      label: 'Include type'
+      selector: /type
     - name: name
       label: 'Media Name'
       selector: /name/0/value
@@ -64,11 +65,12 @@ process:
     source: changed
     callable: strtotime
   name: name
-  # type:
-  #   plugin: skip_on_value
-  #   method: row
-  #   source: type
-  #   value: file--file
+  # Retained for backwards-compatibility.
+  type:
+    plugin: skip_on_value
+    method: row
+    source: type
+    value: file--file
   bundle:
     plugin: default_value
     default_value: image

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_blog_image.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_blog_image.yml
@@ -9,8 +9,9 @@ deriver: Drupal\openy_gc_shared_content_server\SourceMigrationDeriver
 label: Fetch Image
 source:
   entity_type: vy_blog_post
-  # json_includes:
-  #   - field_vy_blog_image.field_media_image
+  # Retained for backwards-compatibility.
+  json_includes:
+    - field_vy_blog_image.field_media_image
   plugin: url
   data_fetcher_plugin: http
   # Specifies the JSON parser plugin.

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_blog_image.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_blog_image.yml
@@ -9,8 +9,8 @@ deriver: Drupal\openy_gc_shared_content_server\SourceMigrationDeriver
 label: Fetch Image
 source:
   entity_type: vy_blog_post
-  json_includes:
-    - field_vy_blog_image.field_media_image
+  # json_includes:
+  #   - field_vy_blog_image.field_media_image
   plugin: url
   data_fetcher_plugin: http
   # Specifies the JSON parser plugin.
@@ -23,29 +23,29 @@ source:
     x-shared-referer: SHARED_CONTENT_REFERRER_WEBSITE
     authorization: SHARED_CONTENT_CONNECTION_TOKEN
   urls: replace_me
-  item_selector: included/
+  item_selector: included/field_vy_blog_image
   fields:
     - name: id
       label: 'id'
-      selector: /id
-    - name: type
-      label: 'Include type'
-      selector: /type
+      selector: /uuid/0/value
+    # - name: type
+    #   label: 'Include type'
+    #   selector: /type
     - name: name
       label: 'Media Name'
-      selector: /attributes/name
+      selector: /name/0/value
     - name: created
       label: 'Created'
-      selector: /attributes/created
+      selector: /created/0/value
     - name: changed
       label: 'Changed'
-      selector: /attributes/changed
+      selector: /changed/0/value
     - name: status
       label: 'Status'
-      selector: /attributes/status
+      selector: /status/0/value
     - name: field_media_image
       label: 'File'
-      selector: /relationships/field_media_image/data/id
+      selector: /field_media_image/0/target_uuid
   ids:
     id:
       type: string
@@ -63,11 +63,11 @@ process:
     source: changed
     callable: strtotime
   name: name
-  type:
-    plugin: skip_on_value
-    method: row
-    source: type
-    value: file--file
+  # type:
+  #   plugin: skip_on_value
+  #   method: row
+  #   source: type
+  #   value: file--file
   bundle:
     plugin: default_value
     default_value: image

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_video.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_video.yml
@@ -8,8 +8,8 @@ label: Import Virtual Y videos
 deriver: Drupal\openy_gc_shared_content_server\SourceMigrationDeriver
 source:
   entity_type: gc_video
-  json_includes:
-    - field_gc_video_media
+  # json_includes:
+  #   - field_gc_video_media
   plugin: url
   track_changes: true
   data_fetcher_plugin: http
@@ -22,38 +22,38 @@ source:
     x-shared-referer: SHARED_CONTENT_REFERRER_WEBSITE
     authorization: SHARED_CONTENT_CONNECTION_TOKEN
   urls: replace_me
-  item_selector: included/
+  item_selector: included/field_gc_video_media
   fields:
     - name: id
       label: 'id'
-      selector: /id
+      selector: /uuid/0/value
     - name: name
       label: 'Name'
-      selector: /attributes/name
+      selector: /name/0/value
     - name: created
       label: 'Created'
-      selector: /attributes/created
+      selector: /created/0/value
     - name: changed
       label: 'Changed'
-      selector: /attributes/changed
+      selector: /changed/0/value
     - name: status
       label: 'Status'
-      selector: /attributes/status
-    - name: type
-      label: 'Type'
-      selector: /type
+      selector: /status/0/value
+    # - name: type
+    #   label: 'Type'
+    #   selector: /type
     - name: field_media_in_library
       label: 'Media in library'
-      selector: /attributes/field_media_in_library
+      selector: /field_media_in_library/0/value
     - name: field_media_source
       label: 'Media source'
-      selector: /attributes/field_media_source
+      selector: /field_media_source/0/value
     - name: field_media_video_embed_field
       label: 'Video Embed'
-      selector: /attributes/field_media_video_embed_field
+      selector: /field_media_video_embed_field/0/value
     - name: field_media_video_id
       label: 'Video ID'
-      selector: /attributes/field_media_video_id
+      selector: /field_media_video_id/0/value
   ids:
     id:
       type: string

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_video.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_video.yml
@@ -8,8 +8,9 @@ label: Import Virtual Y videos
 deriver: Drupal\openy_gc_shared_content_server\SourceMigrationDeriver
 source:
   entity_type: gc_video
-  # json_includes:
-  #   - field_gc_video_media
+  # Retained for backwards-compatibility.
+  json_includes:
+    - field_gc_video_media
   plugin: url
   track_changes: true
   data_fetcher_plugin: http

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_video.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_video.yml
@@ -40,9 +40,10 @@ source:
     - name: status
       label: 'Status'
       selector: /status/0/value
-    # - name: type
-    #   label: 'Type'
-    #   selector: /type
+    # Retained for backwards-compatibility.
+    - name: type
+      label: 'Type'
+      selector: /type
     - name: field_media_in_library
       label: 'Media in library'
       selector: /field_media_in_library/0/value

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_video_image.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_video_image.yml
@@ -29,9 +29,10 @@ source:
     - name: id
       label: 'id'
       selector: /uuid/0/value
-    # - name: type
-    #   label: 'Include type'
-    #   selector: /type
+    # Retained for backwards-compatibility.
+    - name: type
+      label: 'Include type'
+      selector: /type
     - name: name
       label: 'Media Name'
       selector: /name/0/value
@@ -64,11 +65,12 @@ process:
     source: changed
     callable: strtotime
   name: name
-  # type:
-  #   plugin: skip_on_value
-  #   method: row
-  #   source: type
-  #   value: file--file
+  # Retained for backwards-compatibility.
+  type:
+    plugin: skip_on_value
+    method: row
+    source: type
+    value: file--file
   bundle:
     plugin: default_value
     default_value: image

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_video_image.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_video_image.yml
@@ -9,8 +9,9 @@ deriver: Drupal\openy_gc_shared_content_server\SourceMigrationDeriver
 label: Fetch Image
 source:
   entity_type: gc_video
-  # json_includes:
-  #   - field_gc_video_image.field_media_image
+  # Retained for backwards-compatibility.
+  json_includes:
+    - field_gc_video_image.field_media_image
   plugin: url
   data_fetcher_plugin: http
   # Specifies the JSON parser plugin.

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_video_image.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_media_video_image.yml
@@ -9,8 +9,8 @@ deriver: Drupal\openy_gc_shared_content_server\SourceMigrationDeriver
 label: Fetch Image
 source:
   entity_type: gc_video
-  json_includes:
-    - field_gc_video_image.field_media_image
+  # json_includes:
+  #   - field_gc_video_image.field_media_image
   plugin: url
   data_fetcher_plugin: http
   # Specifies the JSON parser plugin.
@@ -23,29 +23,29 @@ source:
     x-shared-referer: SHARED_CONTENT_REFERRER_WEBSITE
     authorization: SHARED_CONTENT_CONNECTION_TOKEN
   urls: replace_me
-  item_selector: included/
+  item_selector: included/field_gc_video_image
   fields:
     - name: id
       label: 'id'
-      selector: /id
-    - name: type
-      label: 'Include type'
-      selector: /type
+      selector: /uuid/0/value
+    # - name: type
+    #   label: 'Include type'
+    #   selector: /type
     - name: name
       label: 'Media Name'
-      selector: /attributes/name
+      selector: /name/0/value
     - name: created
       label: 'Created'
-      selector: /attributes/created
+      selector: /created/0/value
     - name: changed
       label: 'Changed'
-      selector: /attributes/changed
+      selector: /changed/0/value
     - name: status
       label: 'Status'
-      selector: /attributes/status
+      selector: /status/0/value
     - name: field_media_image
       label: 'File'
-      selector: /relationships/field_media_image/data/id
+      selector: /field_media_image/0/target_uuid
   ids:
     id:
       type: string
@@ -63,11 +63,11 @@ process:
     source: changed
     callable: strtotime
   name: name
-  type:
-    plugin: skip_on_value
-    method: row
-    source: type
-    value: file--file
+  # type:
+  #   plugin: skip_on_value
+  #   method: row
+  #   source: type
+  #   value: file--file
   bundle:
     plugin: default_value
     default_value: image

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_node_blog.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_node_blog.yml
@@ -47,6 +47,9 @@ source:
     - name: field_vy_blog_description
       label: 'Blog description'
       selector: /field_vy_blog_description/0/value
+    - name: field_gc_video_category_id
+      label: 'Category'
+      selector: /field_gc_video_category
   ids:
     nid:
       type: integer
@@ -82,6 +85,14 @@ process:
     plugin: migration_lookup
     migration: virtual_y_shared_media_blog_image:REPLACE_ME
     source: field_vy_blog_image_id
+  field_gc_video_category:
+    plugin: sub_process
+    source: field_gc_video_category_id
+    process:
+      target_id:
+        plugin: migration_lookup
+        migration: virtual_y_shared_gc_category_blog:REPLACE_ME
+        source: target_uuid
 destination:
   plugin: 'entity:node'
   default_bundle: vy_blog_post

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_node_blog.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_node_blog.yml
@@ -28,25 +28,25 @@ source:
   fields:
     - name: nid
       label: 'nid'
-      selector: /attributes/drupal_internal__nid
+      selector: /nid/0/value
     - name: title
       label: 'Title'
-      selector: /attributes/title
+      selector: /title/0/value
     - name: created
       label: 'Created'
-      selector: /attributes/created
+      selector: /created/0/value
     - name: changed
       label: 'Changed'
-      selector: /attributes/changed
+      selector: /changed/0/value
     - name: status
       label: 'Status'
-      selector: /attributes/status
+      selector: /status/0/value
     - name: field_vy_blog_image_id
       label: 'Image'
-      selector: /relationships/field_vy_blog_image/data/id
+      selector: /field_vy_blog_image/0/target_uuid
     - name: field_vy_blog_description
       label: 'Blog description'
-      selector: /attributes/field_vy_blog_description/value
+      selector: /field_vy_blog_description/0/value
   ids:
     nid:
       type: integer

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_node_video.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_node_video.yml
@@ -28,43 +28,43 @@ source:
   fields:
     - name: nid
       label: 'nid'
-      selector: /attributes/drupal_internal__nid
+      selector: /nid/0/value
     - name: title
       label: 'Title'
-      selector: /attributes/title
+      selector: /title/0/value
     - name: created
       label: 'Created'
-      selector: /attributes/created
+      selector: /created/0/value
     - name: changed
       label: 'Changed'
-      selector: /attributes/changed
+      selector: /changed/0/value
     - name: status
       label: 'Status'
-      selector: /attributes/status
+      selector: /status/0/value
     - name: field_gc_video_instructor
       label: 'Instructor Name'
-      selector: /attributes/field_gc_video_instructor
+      selector: /field_gc_video_instructor/0/value
     - name: field_gc_video_media_id
       label: 'Video'
-      selector: /relationships/field_gc_video_media/data/id
+      selector: /field_gc_video_media/0/target_uuid
     - name: field_gc_video_description
       label: 'Video description'
-      selector: /attributes/field_gc_video_description/value
+      selector: /field_gc_video_description/0/value
     - name: field_gc_video_duration
       label: 'Duration'
-      selector: /attributes/field_gc_video_duration
+      selector: /field_gc_video_duration/0/value
     - name: field_gc_video_image_id
       label: 'Teaser image'
-      selector: /relationships/field_gc_video_image/data/id
+      selector: /field_gc_video_image/0/target_uuid
     - name: field_gc_video_category_id
       label: 'Category'
-      selector: /relationships/field_gc_video_category/data/id
+      selector: /field_gc_video_category/0/target_uuid
     - name: field_gc_video_equipment_id
       label: 'Equipment'
-      selector: /relationships/field_gc_video_equipment/data/id
+      selector: /field_gc_video_equipment/0/target_uuid
     - name: field_gc_video_level_id
       label: 'Level'
-      selector: /relationships/field_gc_video_level/data/id
+      selector: /field_gc_video_level/0/target_uuid
   ids:
     nid:
       type: integer

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_node_video.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_node_video.yml
@@ -61,7 +61,7 @@ source:
       selector: /field_gc_video_category/0/target_uuid
     - name: field_gc_video_equipment_id
       label: 'Equipment'
-      selector: /field_gc_video_equipment/0/target_uuid
+      selector: /field_gc_video_equipment
     - name: field_gc_video_level_id
       label: 'Level'
       selector: /field_gc_video_level/0/target_uuid
@@ -109,9 +109,13 @@ process:
     migration: virtual_y_shared_gc_category:REPLACE_ME
     source: field_gc_video_category_id
   field_gc_video_equipment:
-    plugin: migration_lookup
-    migration: virtual_y_shared_gc_equipment:REPLACE_ME
+    plugin: sub_process
     source: field_gc_video_equipment_id
+    process:
+      target_id:
+        plugin: migration_lookup
+        migration: virtual_y_shared_gc_equipment:REPLACE_ME
+        source: target_uuid
   field_gc_video_level:
     plugin: migration_lookup
     migration: virtual_y_shared_gc_level:REPLACE_ME

--- a/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_node_video.yml
+++ b/modules/openy_gc_shared_content_server/migrations/migrate_plus.migration.virtual_y_shared_node_video.yml
@@ -58,7 +58,7 @@ source:
       selector: /field_gc_video_image/0/target_uuid
     - name: field_gc_video_category_id
       label: 'Category'
-      selector: /field_gc_video_category/0/target_uuid
+      selector: /field_gc_video_category
     - name: field_gc_video_equipment_id
       label: 'Equipment'
       selector: /field_gc_video_equipment
@@ -105,9 +105,13 @@ process:
     migration: virtual_y_shared_media_video_image:REPLACE_ME
     source: field_gc_video_image_id
   field_gc_video_category:
-    plugin: migration_lookup
-    migration: virtual_y_shared_gc_category:REPLACE_ME
+    plugin: sub_process
     source: field_gc_video_category_id
+    process:
+      target_id:
+        plugin: migration_lookup
+        migration: virtual_y_shared_gc_category:REPLACE_ME
+        source: target_uuid
   field_gc_video_equipment:
     plugin: sub_process
     source: field_gc_video_equipment_id

--- a/modules/openy_gc_shared_content_server/openy_gc_shared_content_server.info.yml
+++ b/modules/openy_gc_shared_content_server/openy_gc_shared_content_server.info.yml
@@ -6,6 +6,7 @@ version: 0.1
 core: 8.x
 core_version_requirement: ^8 || ^9
 dependencies:
+  - drupal:big_pipe
   - drupal:openy_gc_shared_content
   - drupal:csv_serialization
   - drupal:views_data_export

--- a/modules/openy_gc_shared_content_server/openy_gc_shared_content_server.install
+++ b/modules/openy_gc_shared_content_server/openy_gc_shared_content_server.install
@@ -95,3 +95,25 @@ function openy_gc_shared_content_server_update_8002() {
 
   $definition_update_manager->installFieldStorageDefinition('sync_enabled', 'shared_content_source', 'shared_content_source', $status);
 }
+
+/**
+ * Add `api_updated` field to 'shared_content_source' entity type.
+ */
+function openy_gc_shared_content_server_update_8003() {
+  $definition_update_manager = \Drupal::entityDefinitionUpdateManager();
+
+  $status = BaseFieldDefinition::create('boolean')
+    ->setLabel(t('API Updated'))
+    ->setDescription(t('Indicates whether the Shared content source is using the updated API.'))
+    ->setDisplayOptions('form', [
+      'type' => 'boolean_checkbox',
+      'settings' => [
+        'display_label' => TRUE,
+      ],
+      'weight' => 5,
+    ])
+    ->setDisplayConfigurable('form', TRUE)
+    ->setDefaultValue(0);
+
+  $definition_update_manager->installFieldStorageDefinition('api_updated', 'shared_content_source', 'shared_content_source', $status);
+}

--- a/modules/openy_gc_shared_content_server/openy_gc_shared_content_server.install
+++ b/modules/openy_gc_shared_content_server/openy_gc_shared_content_server.install
@@ -117,3 +117,10 @@ function openy_gc_shared_content_server_update_8003() {
 
   $definition_update_manager->installFieldStorageDefinition('api_updated', 'shared_content_source', 'shared_content_source', $status);
 }
+
+/**
+ * Enable big_pipe.
+ */
+function openy_gc_shared_content_server_update_8004() {
+  \Drupal::service('module_installer')->install(['big_pipe'], TRUE);
+}

--- a/modules/openy_gc_shared_content_server/src/Entity/SharedContentSource.php
+++ b/modules/openy_gc_shared_content_server/src/Entity/SharedContentSource.php
@@ -132,6 +132,13 @@ class SharedContentSource extends ContentEntityBase {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function getApiUpdated() {
+    return (bool) $this->get('api_updated')->value;
+  }
+
+  /**
    * {@inheritDoc}
    */
   public function isUpdated() {
@@ -151,6 +158,8 @@ class SharedContentSource extends ContentEntityBase {
     if ($status == '200') {
       return TRUE;
     }
+
+    return FALSE;
   }
 
   /**

--- a/modules/openy_gc_shared_content_server/src/Entity/SharedContentSource.php
+++ b/modules/openy_gc_shared_content_server/src/Entity/SharedContentSource.php
@@ -132,6 +132,28 @@ class SharedContentSource extends ContentEntityBase {
   }
 
   /**
+   * {@inheritDoc}
+   */
+  public function isUpdated() {
+    $url = $this->getUrl();
+
+    // If there's no url then we're done.
+    if (empty($url)) {
+      return FALSE;
+    }
+
+    // Attempt to hit the new endpoint and get the status code.
+    // Without the proper headers it will still return 200, but no content.
+    $url .= '/api/virtual-y/shared-content-source/gc_video';
+    $client = \Drupal::httpClient();
+    $status = $client->get($url, ['http_errors' => FALSE])->getStatusCode();
+
+    if ($status == '200') {
+      return TRUE;
+    }
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function preSave(EntityStorageInterface $storage) {
@@ -229,6 +251,19 @@ class SharedContentSource extends ContentEntityBase {
     $fields['sync_enabled'] = BaseFieldDefinition::create('boolean')
       ->setLabel(t('Sync Enabled'))
       ->setDescription(t('Indicating whether the Shared content source enabled for sync.'))
+      ->setDisplayOptions('form', [
+        'type' => 'boolean_checkbox',
+        'settings' => [
+          'display_label' => TRUE,
+        ],
+        'weight' => 5,
+      ])
+      ->setDisplayConfigurable('form', TRUE)
+      ->setDefaultValue(0);
+
+    $fields['api_updated'] = BaseFieldDefinition::create('boolean')
+      ->setLabel(t('API Updated'))
+      ->setDescription(t('Indicates whether the Shared content source is using the updated API.'))
       ->setDisplayOptions('form', [
         'type' => 'boolean_checkbox',
         'settings' => [

--- a/modules/openy_gc_shared_content_server/src/Form/SharedContentSourceForm.php
+++ b/modules/openy_gc_shared_content_server/src/Form/SharedContentSourceForm.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\openy_gc_shared_content_server\Form;
 
+use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Entity\ContentEntityForm;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -34,10 +35,32 @@ class SharedContentSourceForm extends ContentEntityForm {
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
-    /**
-     * @var \Drupal\openy_gc_shared_content_server\Entity\SharedContentSource $entity
-     */
     $form = parent::buildForm($form, $form_state);
+
+    /** @var \Drupal\openy_gc_shared_content_server\Entity\SharedContentSource $entity */
+    $entity = $this->entity;
+
+    // If the source api is not updated, check to see if it's capable.
+    if (!empty($entity->getUrl()) && isset($form["api_updated"]) &&
+        $form["api_updated"]["widget"]["value"]["#default_value"] !== TRUE) {
+      $title = $form['api_updated']['widget']['#title']->__toString();
+      $updated = $entity->isUpdated();
+
+      // If the source isn't updated, don't allow the field to be modified.
+      $status = new FormattableMarkup('<em class="color-warning">@status</em>', ['@status' => 'Nope.']);
+      $form["api_updated"]["#disabled"] = 'disabled';
+
+      // If it is updated, yay!
+      if ($updated) {
+        $status = new FormattableMarkup(
+          '<em class="color-success">@status</em>',
+          ['@status' => 'New API Available!']
+        );
+        unset($form["api_updated"]["#disabled"]);
+      }
+      $form['api_updated']['widget']['value']['#title'] =
+        $this->t('@title - @status', ['@title' => $title, '@status' => $status]);
+    }
 
     return $form;
   }

--- a/modules/openy_gc_shared_content_server/src/Form/SharedContentSourceForm.php
+++ b/modules/openy_gc_shared_content_server/src/Form/SharedContentSourceForm.php
@@ -41,14 +41,14 @@ class SharedContentSourceForm extends ContentEntityForm {
     $entity = $this->entity;
 
     // If the source api is not updated, check to see if it's capable.
-    if (!empty($entity->getUrl()) && isset($form["api_updated"]) &&
-        $form["api_updated"]["widget"]["value"]["#default_value"] !== TRUE) {
+    if (!empty($entity->getUrl()) && isset($form['api_updated']) &&
+        $form['api_updated']['widget']['value']['#default_value'] !== TRUE) {
       $title = $form['api_updated']['widget']['#title']->__toString();
       $updated = $entity->isUpdated();
 
       // If the source isn't updated, don't allow the field to be modified.
       $status = new FormattableMarkup('<em class="color-warning">@status</em>', ['@status' => 'Nope.']);
-      $form["api_updated"]["#disabled"] = 'disabled';
+      $form['api_updated']['#disabled'] = 'disabled';
 
       // If it is updated, yay!
       if ($updated) {
@@ -56,7 +56,7 @@ class SharedContentSourceForm extends ContentEntityForm {
           '<em class="color-success">@status</em>',
           ['@status' => 'New API Available!']
         );
-        unset($form["api_updated"]["#disabled"]);
+        unset($form['api_updated']['#disabled']);
       }
       $form['api_updated']['widget']['value']['#title'] =
         $this->t('@title - @status', ['@title' => $title, '@status' => $status]);

--- a/modules/openy_gc_shared_content_server/src/SharedContentSourceListBuilder.php
+++ b/modules/openy_gc_shared_content_server/src/SharedContentSourceListBuilder.php
@@ -5,8 +5,8 @@ namespace Drupal\openy_gc_shared_content_server;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityListBuilder;
 use Drupal\Core\Link;
-use Drupal\Core\Security\TrustedCallbackInterface;
 use Drupal\Core\Render\Markup;
+use Drupal\Core\Security\TrustedCallbackInterface;
 
 /**
  * Defines a class to build a listing of Shared content source entities.
@@ -90,10 +90,10 @@ class SharedContentSourceListBuilder extends EntityListBuilder implements Truste
   }
 
   /**
-   * #lazy_builder callback; replaces placeholder with messages.
+   * The #lazy_builder callback; replaces placeholder with messages.
    *
    * @param string $url
-   *   The url to check
+   *   The url to check.
    * @param bool $is_updated
    *   If the source server has already been updated to the new version.
    *

--- a/modules/openy_gc_shared_content_server/src/SharedContentSourceListBuilder.php
+++ b/modules/openy_gc_shared_content_server/src/SharedContentSourceListBuilder.php
@@ -20,6 +20,7 @@ class SharedContentSourceListBuilder extends EntityListBuilder {
     $header['id'] = $this->t('Shared content source ID');
     $header['status'] = $this->t('Status');
     $header['sync_enabled'] = $this->t('Sync Enabled');
+    $header['api_updated'] = $this->t('API Version');
     $header['name'] = $this->t('Name');
     $header['url'] = $this->t('Url');
     return $header + parent::buildHeader();
@@ -55,6 +56,25 @@ class SharedContentSourceListBuilder extends EntityListBuilder {
     }
 
     $row['sync_enabled']['data'] = [
+      '#type' => 'inline_template',
+      '#template' => '<span style="color: ' . $color . ';">{{ content }}</span>',
+      '#context' => [
+        'content' => $text,
+      ],
+    ];
+
+    $color = '#ff0000';
+    $text = $this->t('Old');
+    if ($entity->api_updated->value == 1) {
+      $color = '#008000';
+      $text = $this->t('New');
+    }
+    if ($entity->api_updated->value == 0 && $entity->isUpdated()) {
+      $color = '#ffa500';
+      $text = $this->t('Updatable!');
+    }
+
+    $row['api_updated']['data'] = [
       '#type' => 'inline_template',
       '#template' => '<span style="color: ' . $color . ';">{{ content }}</span>',
       '#context' => [

--- a/modules/openy_gc_shared_content_server/src/SourceMigrationDeriver.php
+++ b/modules/openy_gc_shared_content_server/src/SourceMigrationDeriver.php
@@ -175,13 +175,13 @@ class SourceMigrationDeriver extends DeriverBase implements DeriverInterface, Co
       $base_plugin_definition['migration_dependencies']['required'][] = $migration;
     }
 
-    if (!empty($base_plugin_definition['process']['field_gc_video_category'])) {
+    if (!empty($base_plugin_definition['process']['field_gc_video_category']['process']['target_id'])) {
       $migration = str_replace(
         'REPLACE_ME',
         $this->getKey($url),
-        $base_plugin_definition['process']['field_gc_video_category']['migration']
+        $base_plugin_definition['process']['field_gc_video_category']['process']['target_id']['migration']
       );
-      $base_plugin_definition['process']['field_gc_video_category']['migration'] = $migration;
+      $base_plugin_definition['process']['field_gc_video_category']['process']['target_id']['migration'] = $migration;
       $base_plugin_definition['migration_dependencies']['required'][] = $migration;
     }
 
@@ -192,6 +192,7 @@ class SourceMigrationDeriver extends DeriverBase implements DeriverInterface, Co
         $base_plugin_definition['process']['field_gc_video_equipment']['process']['target_id']['migration']
       );
       $base_plugin_definition['process']['field_gc_video_equipment']['process']['target_id']['migration'] = $migration;
+      $base_plugin_definition['migration_dependencies']['required'][] = $migration;
     }
 
     if (!empty($base_plugin_definition['process']['field_gc_video_level'])) {
@@ -270,8 +271,7 @@ class SourceMigrationDeriver extends DeriverBase implements DeriverInterface, Co
       '/attributes/title' => '/title/0/value',
       '/attributes/uri/url' => '/uri/0/url',
       '/id' => '/uuid/0/value',
-      '/relationships/field_gc_video_category/data/id' => '/field_gc_video_category/0/target_uuid',
-      '/relationships/field_gc_video_equipment/data/id' => '/field_gc_video_equipment/0/target_uuid',
+      '/relationships/field_gc_video_category/data' => '/field_gc_video_category',
       '/relationships/field_gc_video_equipment/data' => '/field_gc_video_equipment',
       '/relationships/field_gc_video_image/data/id' => '/field_gc_video_image/0/target_uuid',
       '/relationships/field_gc_video_level/data/id' => '/field_gc_video_level/0/target_uuid',

--- a/modules/openy_gc_shared_content_server/src/SourceMigrationDeriver.php
+++ b/modules/openy_gc_shared_content_server/src/SourceMigrationDeriver.php
@@ -185,14 +185,13 @@ class SourceMigrationDeriver extends DeriverBase implements DeriverInterface, Co
       $base_plugin_definition['migration_dependencies']['required'][] = $migration;
     }
 
-    if (!empty($base_plugin_definition['process']['field_gc_video_equipment'])) {
+    if (!empty($base_plugin_definition['process']['field_gc_video_equipment']['process']['target_id'])) {
       $migration = str_replace(
         'REPLACE_ME',
         $this->getKey($url),
-        $base_plugin_definition['process']['field_gc_video_equipment']['migration']
+        $base_plugin_definition['process']['field_gc_video_equipment']['process']['target_id']['migration']
       );
-      $base_plugin_definition['process']['field_gc_video_equipment']['migration'] = $migration;
-      $base_plugin_definition['migration_dependencies']['required'][] = $migration;
+      $base_plugin_definition['process']['field_gc_video_equipment']['process']['target_id']['migration'] = $migration;
     }
 
     if (!empty($base_plugin_definition['process']['field_gc_video_level'])) {

--- a/modules/openy_gc_shared_content_server/src/SourceMigrationDeriver.php
+++ b/modules/openy_gc_shared_content_server/src/SourceMigrationDeriver.php
@@ -272,6 +272,7 @@ class SourceMigrationDeriver extends DeriverBase implements DeriverInterface, Co
       '/id' => '/uuid/0/value',
       '/relationships/field_gc_video_category/data/id' => '/field_gc_video_category/0/target_uuid',
       '/relationships/field_gc_video_equipment/data/id' => '/field_gc_video_equipment/0/target_uuid',
+      '/relationships/field_gc_video_equipment/data' => '/field_gc_video_equipment',
       '/relationships/field_gc_video_image/data/id' => '/field_gc_video_image/0/target_uuid',
       '/relationships/field_gc_video_level/data/id' => '/field_gc_video_level/0/target_uuid',
       '/relationships/field_gc_video_media/data/id' => '/field_gc_video_media/0/target_uuid',
@@ -288,6 +289,12 @@ class SourceMigrationDeriver extends DeriverBase implements DeriverInterface, Co
 
     if (strstr($base_plugin_definition["source"]["item_selector"], 'included/')) {
       $base_plugin_definition["source"]["item_selector"] = 'included/';
+    }
+
+    foreach ($base_plugin_definition["process"] as $name => $keys) {
+      if ($keys['plugin'] == 'sub_process') {
+        $base_plugin_definition['process'][$name]['process']['target_id']['source'] = 'id';
+      }
     }
 
     return $base_plugin_definition;

--- a/modules/openy_gc_shared_content_server/src/SourceMigrationDeriver.php
+++ b/modules/openy_gc_shared_content_server/src/SourceMigrationDeriver.php
@@ -203,6 +203,13 @@ class SourceMigrationDeriver extends DeriverBase implements DeriverInterface, Co
       $base_plugin_definition['migration_dependencies']['required'][] = $migration;
     }
 
+    // Rewrite fields for backwards-compatibility.
+    if (!$updated) {
+      if (isset($base_plugin_definition["source"]["fields"])) {
+        $base_plugin_definition = $this->rewriteFieldSelectors($base_plugin_definition);
+      }
+    }
+
     return $base_plugin_definition;
   }
 
@@ -233,6 +240,54 @@ class SourceMigrationDeriver extends DeriverBase implements DeriverInterface, Co
     $url_key = str_replace('https://', '', $url_key);
     $url_key = str_replace(['.', '-'], '_', $url_key);
     return $url_key;
+  }
+
+  /**
+   * Helper function to rewrite fields to old values.
+   *
+   * @param array $base_plugin_definition
+   *   Migration array.
+   *
+   * @return array
+   *   Updated plugin data.
+   */
+  private function rewriteFieldSelectors(array $base_plugin_definition) {
+    $selectors = [
+      '/attributes/changed' => '/changed/0/value',
+      '/attributes/created' => '/created/0/value',
+      '/attributes/drupal_internal__nid' => '/nid/0/value',
+      '/attributes/field_gc_video_description/value' => '/field_gc_video_description/0/value',
+      '/attributes/field_gc_video_duration' => '/field_gc_video_duration/0/value',
+      '/attributes/field_gc_video_instructor' => '/field_gc_video_instructor/0/value',
+      '/attributes/field_media_in_library' => '/field_media_in_library/0/value',
+      '/attributes/field_media_source' => '/field_media_source/0/value',
+      '/attributes/field_media_video_embed_field' => '/field_media_video_embed_field/0/value',
+      '/attributes/field_media_video_id' => '/field_media_video_id/0/value',
+      '/attributes/field_vy_blog_description/value' => '/field_vy_blog_description/0/value',
+      '/attributes/filemime' => '/filemime/0/value',
+      '/attributes/filename' => '/filename/0/value',
+      '/attributes/name' => '/name/0/value',
+      '/attributes/status' => '/status/0/value',
+      '/attributes/title' => '/title/0/value',
+      '/attributes/uri/url' => '/uri/0/url',
+      '/id' => '/uuid/0/value',
+      '/relationships/field_gc_video_category/data/id' => '/field_gc_video_category/0/target_uuid',
+      '/relationships/field_gc_video_equipment/data/id' => '/field_gc_video_equipment/0/target_uuid',
+      '/relationships/field_gc_video_image/data/id' => '/field_gc_video_image/0/target_uuid',
+      '/relationships/field_gc_video_level/data/id' => '/field_gc_video_level/0/target_uuid',
+      '/relationships/field_gc_video_media/data/id' => '/field_gc_video_media/0/target_uuid',
+      '/relationships/field_media_image/data/id' => '/field_media_image/0/target_uuid',
+      '/relationships/field_vy_blog_image/data/id' => '/field_vy_blog_image/0/target_uuid',
+    ];
+    $old_values = array_keys($selectors);
+    $new_values = array_values($selectors);
+
+    foreach ($base_plugin_definition["source"]["fields"] as $index => $field) {
+      $replacement = str_replace($new_values, $old_values, $field['selector']);
+      $base_plugin_definition["source"]["fields"][$index]['selector'] = $replacement;
+    }
+
+    return $base_plugin_definition;
   }
 
 }

--- a/modules/openy_gc_shared_content_server/src/SourceMigrationDeriver.php
+++ b/modules/openy_gc_shared_content_server/src/SourceMigrationDeriver.php
@@ -282,17 +282,17 @@ class SourceMigrationDeriver extends DeriverBase implements DeriverInterface, Co
     $old_selectors = array_keys($selectors);
     $new_selectors = array_values($selectors);
 
-    foreach ($base_plugin_definition["source"]["fields"] as $index => $field) {
+    foreach ($base_plugin_definition['source']['fields'] as $index => $field) {
       $replacement = str_replace($new_selectors, $old_selectors, $field['selector']);
-      $base_plugin_definition["source"]["fields"][$index]['selector'] = $replacement;
+      $base_plugin_definition['source']['fields'][$index]['selector'] = $replacement;
     }
 
-    if (strstr($base_plugin_definition["source"]["item_selector"], 'included/')) {
-      $base_plugin_definition["source"]["item_selector"] = 'included/';
+    if (strstr($base_plugin_definition['source']['item_selector'], 'included/')) {
+      $base_plugin_definition['source']['item_selector'] = 'included/';
     }
 
-    foreach ($base_plugin_definition["process"] as $name => $keys) {
-      if ($keys['plugin'] == 'sub_process') {
+    foreach ($base_plugin_definition['process'] as $name => $keys) {
+      if (isset($keys['plugin']) && $keys['plugin'] == 'sub_process') {
         $base_plugin_definition['process'][$name]['process']['target_id']['source'] = 'id';
       }
     }

--- a/modules/openy_gc_shared_content_server/src/SourceMigrationDeriver.php
+++ b/modules/openy_gc_shared_content_server/src/SourceMigrationDeriver.php
@@ -287,6 +287,10 @@ class SourceMigrationDeriver extends DeriverBase implements DeriverInterface, Co
       $base_plugin_definition["source"]["fields"][$index]['selector'] = $replacement;
     }
 
+    if (strstr($base_plugin_definition["source"]["item_selector"], 'included/')) {
+      $base_plugin_definition["source"]["item_selector"] = 'included/';
+    }
+
     return $base_plugin_definition;
   }
 

--- a/src/SegmentContentAccessCheck.php
+++ b/src/SegmentContentAccessCheck.php
@@ -175,7 +175,7 @@ class SegmentContentAccessCheck implements ContainerInjectionInterface {
   private function isValidSharedClient() {
     // Validate by field_gc_share.
     $query = $this->request->query->all();
-    if (!isset($query['filter']['field_gc_share']) && !(bool) $query['filter']['field_gc_share']) {
+    if (strstr($this->request->getPathInfo(), 'jsonapi') && !isset($query['filter']['field_gc_share']) && !(bool) $query['filter']['field_gc_share']) {
       return FALSE;
     }
 


### PR DESCRIPTION
Do not merge PR, only review it and approve/request changes.
Merge is allowed by QA Engineer only.

**Related Issue/Ticket:**

**PLEASE CHECK BASE BRANCH FOR YOUR PR**
**ONLY urgent and approved fixes for point release should go to master branch**

[PRODDEV-228](https://openy.atlassian.net/browse/PRODDEV-228)

## WIP Tasks

- [x] Rebuild endpoint to recreate JSON-API functionality
- [x] Add access checks to endpoint to validate source server token
- [x] Add flag to source server to indicate if they're on the old or new 
- [x] Update migrations in shared_content_server
  - [x] First pass on this
  - [x] Figure out the logic so that both old and new migrations can exist at the same time or be switched. 
  - [x] Update videos migration with new logic
  - [x] Update new logic on Blogs

## Steps to test:

### New endpoint

- [ ] Check `/api/virtual-y/shared-content-source/gc_video` and `/api/virtual-y/shared-content-source/vy_blog_post`. Both should return empty data sets with a 200 when no headers are passed.
- [ ] Test the endpoints as an authenticated user and you should see the data.
- [ ] Test the endpoints with the proper headers and you should also see data. Headers should look like:
  ```
  Accept:application/json; charset=utf-8
  Content-Type:application/json
  x-shared-content:1
  x-shared-referer:http://your.test-server.docksal
  authorization:Bearer the-very-long-token
  ```

### Switcher

- [ ] Enable `openy_gc_shared_content_server` on a site before pulling this branch.
- [ ] Run `drush updb` and observe `openy_gc_shared_content_server_update_8003` runs successfully
- [ ] Visit `/admin/virtual-y/shared-content/shared_content_source`
- [ ] Add a shared content source
  - [ ] Observe the new "API Updated" field. This can be checked immediately to enable admins who know what they're doing to save right away, but for now, leave it blank. 
  ![Add_shared_content_source___Drush_Site-Install](https://user-images.githubusercontent.com/238201/147312129-d505f4e5-b00b-4b34-bbb1-891d98ca3439.png)
  - [ ] After saving, revisit the edit page and observe that the new field has an indicator as to whether the new API is available for that site. Use an updated site to test the positive and an old site or `https://example.com` to test the negative. If the new API is not available the checkbox will be disabled.
  ![Edit_Server___Drush_Site-Install](https://user-images.githubusercontent.com/238201/147312399-6ed722ec-f733-44ae-93d5-15257ee1c276.png)
  ![Edit_Example___Drush_Site-Install](https://user-images.githubusercontent.com/238201/147312426-e88953ed-e93b-472a-a16d-8e03b9a55eec.png)
- [ ] Observe three states of the "API Version" column. "New" servers have the flag set. "Updatable" have responded that they have the new API but have not had the flag set. "Old" are sad.
  ![Shared_content_source_entities___Drush_Site-Install](https://user-images.githubusercontent.com/238201/147312246-6baa5d0a-bfde-4996-bde8-06e5b145726f.png)

### Testing new and old migrations

- Test importing content with the old API
  - [ ] Configure your source as above and leave it set to the old API
  - [ ] For your shared content server, run `drush cr && drush ms`
  - [ ] Import content with `drush mim --group=virtual_y_shared`
  - [ ] Observe the content is imported... check all fields, videos and blogs
  - [ ] roll back the migration with `drush mr --group=virtual_y_shared`
  - [ ] Observe content is gone from the server.
- Test importing content with the new API
  - [ ] Configure your source as above, edit the source, and set `API Updated` to TRUE
  - [ ] For your shared content server, run `drush cr && drush ms`
  - [ ] Import content with `drush mim --group=virtual_y_shared`
  - [ ] Observe the content is imported... check all fields, videos and blogs
  - [ ] roll back the migration with `drush mr --group=virtual_y_shared`
  - [ ] Observe content is gone from the server.

There should be no user-visible differences, but you should be able to see the change in URL with XDebug by sticking a breakpoint in SourceMigrationDeriver::getDerivativeDefinitions and running `drush cr && drush ms`.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [x] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
