### PR TITLE
fix!: Allow installation on Virtual Y on dev Open Y branches

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Open Y Virtual Y Content",
     "type": "drupal-module",
     "require": {
-        "ymcatwincities/openy": "9.*",
+        "ymcatwincities/openy": "9.* || dev-9.x-2.x || dev-*",
         "drupal/recurring_events": "^2.0@beta",
         "ymcatwincities/daxko_sso": "*",
         "drupal/jsonapi_image_styles": "^2.0.0",


### PR DESCRIPTION
Fix-of: https://github.com/ymcatwincities/openy_gated_content/commit/0d4e4d28fec65da7c2e10794501cd7b9ae41ff8a
Addresses: Can't install VIrtual Y on Open Y 9.x-2.x ( sandboxes )

Do not merge PR, only review it and approve/request changes.
Merge is allowed by QA Engineer only.

**Related Issue/Ticket:**

**PLEASE CHECK BASE BRANCH FOR YOUR PR**
**ONLY urgent and approved fixes for point release should go to master branch**

(Replace this line with a link to the related GitHub issue on [ymcatwincities/openy_gated_content](https://github.com/ymcatwincities/openy_gated_content/issues) or your own ticketing system)

## Steps to test:

- [ ] First do this
- [ ] Then do this (and look at this great screenshot).
- [ ] Finally observe the issue is resolved.

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [ ] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [ ] This change does not contain front-end fixes.
- [ ] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
