### PR TITLE
PRODDEV-553 Fix Personal training date discrepancy

### DIFF
--- a/modules/openy_gc_personal_training/openy_gc_personal_training.module
+++ b/modules/openy_gc_personal_training/openy_gc_personal_training.module
@@ -104,8 +104,14 @@ function openy_gc_personal_training_openy_gated_content_list_events_alter(&$resu
       'title' => $item['title'],
       'host_name' => $item['name'],
       'date' => [
-        'value' => (new DrupalDateTime($item['date__value']))->format('c'),
-        'end_value' => (new DrupalDateTime($item['date__end_value']))->format('c'),
+        'value' => (new DrupalDateTime(
+          $item['date__value'],
+          DateTimeItemInterface::STORAGE_TIMEZONE
+        ))->format('c'),
+        'end_value' => (new DrupalDateTime(
+          $item['date__end_value'],
+          DateTimeItemInterface::STORAGE_TIMEZONE
+        ))->format('c'),
       ],
     ];
   }


### PR DESCRIPTION
**Related Issue/Ticket:** 
[PRODDEV-553](https://openy.atlassian.net/browse/PRODDEV-553)

## Steps to test:

Outlined in the related issue [PRODDEV-553](https://openy.atlassian.net/browse/PRODDEV-553)

## Quality checks:

Please check these boxes to confirm this PR covers the following cases:

- Maintaining our upgrade path is essential. Check one or the other:
  - [ ] This PR  provides updates via `hook_update_N` or other means.
  - [x] No updates are necessary for this change.
- Front end fixes should be tested against all of the Open Y Themes.
  - [ ] Tested against Carnation
  - [ ] Tested against Lily
  - [ ] Tested against Rose
  - [x] This change does not contain front-end fixes.
- [x] I have flagged this PR "Needs Review" or pinged the VY devs/QA
  team in Slack
